### PR TITLE
Simple fix of equality check of configurations

### DIFF
--- a/mlptrain/configurations/configuration.py
+++ b/mlptrain/configurations/configuration.py
@@ -183,10 +183,9 @@ class Configuration(AtomCollection):
               and other.charge == self.charge
               and other.box == self.box)
 
-        if self.n_atoms > 0:
+        if eq and self.n_atoms > 0:
             rmsd = np.linalg.norm(self.coordinates - other.coordinates)
             return eq and rmsd < 1E-10
-
         return eq
 
     def copy(self) -> 'Configuration':


### PR DESCRIPTION
Systems with different number of atoms were tested for RMSD
 and triggered numpy error message. Now the test is performed only for
geometries with all properties identical.