### PR TITLE
Set GAP calculator name

### DIFF
--- a/mlptrain/potentials/gap/gap.py
+++ b/mlptrain/potentials/gap/gap.py
@@ -71,8 +71,11 @@ class GAP(MLPotential):
                                       'pip install quippy-ase')
 
         self._check_xml_exists()
-        return quippy.potential.Potential("IP GAP",
-                                          param_filename=self.xml_filename)
+
+        calculator = quippy.potential.Potential("IP GAP",
+                                                param_filename=self.xml_filename)
+        calculator.name = self.name
+        return calculator
 
     @property
     def _train_command(self):


### PR DESCRIPTION
Tried to run `methane.py` with a fresh environment, but still got an error similar to the one in #53.

The relevant ASE files in the master branch do not seem to be modified much compared to older versions, which suggests that the error comes from the updates in quippy.

I was able to make the example work by setting the name of the calculator with the setter method.

[ase/io/trajectory.py comparison](https://github.com/rosswhitfield/ase/compare/3.22.0...master)
[quippy/potential.py](https://github.com/libAtoms/QUIP/blob/public/quippy/quippy/potential.py)