### PR TITLE
Fix single point parallelisation in active learning

### DIFF
--- a/mlptrain/training/active.py
+++ b/mlptrain/training/active.py
@@ -272,7 +272,7 @@ def _add_active_configs(mlp: 'mlptrain.potentials._base.MLPotential',
     if 'method_name' in kwargs and configs.has_a_none_energy:
         for config in configs:
             if config.energy.true is None:
-                config.single_point(kwargs['method_name'])
+                config.single_point(kwargs['method_name'], n_cores=Config.n_cores)
 
     if (kwargs['inherit_metad_bias'] is True
             and kwargs['iteration'] >= kwargs['bias_start_iter']):
@@ -381,7 +381,7 @@ def _gen_active_config(config:      'mlptrain.Configuration',
 
     if selector.select:
         if traj.final_frame.energy.true is None:
-            traj.final_frame.single_point(method_name)
+            traj.final_frame.single_point(method_name, n_cores=n_cores)
 
         return traj.final_frame
 
@@ -396,7 +396,7 @@ def _gen_active_config(config:      'mlptrain.Configuration',
 
             if selector.select:
                 if frame.energy.true is None:
-                    frame.single_point(method_name)
+                    frame.single_point(method_name, n_cores=n_cores)
 
                 return frame
 


### PR DESCRIPTION
Previously, not all available cores were used during active learning (e.g. when using 32 cores for active learning with 4 configurations per iteration, only 1 core per configuration was used for single point calculations instead of the available 8 cores per configuration).