### PR TITLE
Update dscribe to 2.0

### DIFF
--- a/mlptrain/descriptors.py
+++ b/mlptrain/descriptors.py
@@ -52,9 +52,9 @@ def soap_matrix(*args:    Union[mlt.ConfigurationSet, mlt.Configuration],
     # Compute the average SOAP vector where the expansion coefficients are
     # calculated over averages over each site
     soap_desc = SOAP(species=elements,
-                     rcut=5,             # Distance cutoff (Å)
-                     nmax=6,             # Maximum order of the radial
-                     lmax=6,             # Maximum order of the angular
+                     r_cut=5,             # Distance cutoff (Å)
+                     n_max=6,             # Maximum order of the radial
+                     l_max=6,             # Maximum order of the angular
                      average='inner')
 
     soap_vec = soap_desc.create([conf.ase_atoms for conf in configurations])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,7 @@
-numpy<=1.23.5
+numpy
 cython
 scipy
 autode==1.1*
-# ase  # Must be installed from https://github.com/rosswhitfield/ase:master
 coloredlogs
 dscribe==2.0*
 matplotlib-base

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 numpy
+ase # needs to be updated to dev version to use plumed 
 cython
 scipy
 autode==1.1*

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ scipy
 autode==1.1*
 # ase  # Must be installed from https://github.com/rosswhitfield/ase:master
 coloredlogs
-dscribe~=2.0.0
+dscribe==2.0*
 matplotlib-base
 pytest
 py-plumed

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ scipy
 autode==1.1*
 # ase  # Must be installed from https://github.com/rosswhitfield/ase:master
 coloredlogs
-dscribe==1.*
+dscribe~=2.0.0
 matplotlib-base
 pytest
 py-plumed


### PR DESCRIPTION
To add compatibility for numpy 1.24.3 required by the Cirrus facility,  I updated dscribe (needed for SOAP descriptor) to version 2.0 