### PR TITLE
Lazy import scipy.stats and matplotlib.pyplot

### DIFF
--- a/mlptrain/configurations/configuration_set.py
+++ b/mlptrain/configurations/configuration_set.py
@@ -8,7 +8,6 @@ from autode.atoms import elements, Atom
 from mlptrain.config import Config
 from mlptrain.log import logger
 from mlptrain.configurations.configuration import Configuration
-from mlptrain.configurations.plotting import parity_plot
 from mlptrain.box import Box
 
 
@@ -248,6 +247,8 @@ class ConfigurationSet(list):
         Arguments:
             *args: Strings defining the method or MLPs
         """
+        from mlptrain.configurations.plotting import parity_plot
+
         if _num_strings_in(args) > 1:
             raise NotImplementedError('Compare currently only supports a '
                                       'single reference method (string).')

--- a/mlptrain/loss/mean_errors.py
+++ b/mlptrain/loss/mean_errors.py
@@ -1,7 +1,6 @@
 import mlptrain
 import numpy as np
 from abc import ABC, abstractmethod
-from scipy.stats import bootstrap
 from mlptrain.loss._base import LossValue, LossFunction
 
 
@@ -22,6 +21,7 @@ class _DeltaLossFunction(LossFunction, ABC):
 
             mlp: Potential to use
         """
+        from scipy.stats import bootstrap
 
         if self.loss_type is None:
             raise NotImplementedError(f'{self} did not define loss_type')

--- a/mlptrain/sampling/metadynamics.py
+++ b/mlptrain/sampling/metadynamics.py
@@ -8,13 +8,11 @@ import shutil
 import warnings
 import numpy as np
 import multiprocessing as mp
-import matplotlib.pyplot as plt
 import autode as ade
 from typing import Optional, Sequence, Union, Tuple, List
 from multiprocessing import Pool
 from subprocess import Popen
 from copy import deepcopy
-from matplotlib.colors import ListedColormap
 from ase import units as ase_units
 from ase.io import read as ase_read
 from ase.io import write as ase_write
@@ -652,6 +650,7 @@ class Metadynamics:
             time_units: (str) Time units to be used in plotting, available
                               units: 'fs', 'ps', 'ns'
         """
+        import matplotlib.pyplot as plt
 
         filename = f'HILLS_{idx}.dat'
 
@@ -1192,6 +1191,7 @@ class Metadynamics:
                              energy_units: str
                              ) -> None:
         """Plot the standard deviation versus block size"""
+        import matplotlib.pyplot as plt
 
         data_dict.pop('CVs')
         mean_errors = [np.mean(error_grid) for error_grid in data_dict.values()]
@@ -1496,6 +1496,7 @@ class Metadynamics:
                      blocksize:         Optional[int] = None,
                      ) -> None:
         """Plot 1D mean free energy surface with a confidence interval"""
+        import matplotlib.pyplot as plt
         import scipy.stats
 
         logger.info('Plotting 1D FES')
@@ -1555,6 +1556,8 @@ class Metadynamics:
                      blocksize:         Optional[int] = None,
                      ) -> None:
         """Plot 2D mean free energy surface with a confidence interval"""
+        from matplotlib.colors import ListedColormap
+        import matplotlib.pyplot as plt
         import scipy.stats
 
         logger.info('Plotting 2D FES')
@@ -1776,6 +1779,7 @@ class Metadynamics:
         Plot the root mean square difference between free energy surfaces
         as a function of time
         """
+        import matplotlib.pyplot as plt
 
         fes_diff_grids = np.diff(fes_grids, axis=0)
         rms_diffs = [np.sqrt(np.mean(grid * grid)) for grid in fes_diff_grids]
@@ -1806,6 +1810,7 @@ class Metadynamics:
         """
         Plot multiple 1D free energy surfaces as a function of simulation time
         """
+        import matplotlib.pyplot as plt
 
         plotted_cv = self.bias.metad_cvs[0]
 

--- a/mlptrain/sampling/metadynamics.py
+++ b/mlptrain/sampling/metadynamics.py
@@ -15,7 +15,6 @@ from multiprocessing import Pool
 from subprocess import Popen
 from copy import deepcopy
 from matplotlib.colors import ListedColormap
-from scipy.stats import norm
 from ase import units as ase_units
 from ase.io import read as ase_read
 from ase.io import write as ase_write
@@ -1497,6 +1496,7 @@ class Metadynamics:
                      blocksize:         Optional[int] = None,
                      ) -> None:
         """Plot 1D mean free energy surface with a confidence interval"""
+        import scipy.stats.norm
 
         logger.info('Plotting 1D FES')
 
@@ -1515,7 +1515,7 @@ class Metadynamics:
             with warnings.catch_warnings():
                 warnings.filterwarnings('ignore',
                                         message='invalid value encountered in multiply')
-                confidence_interval = norm.interval(confidence_level,
+                confidence_interval = scipy.stats.norm.interval(confidence_level,
                                                     loc=mean_fes,
                                                     scale=fes_error)
 
@@ -1555,6 +1555,7 @@ class Metadynamics:
                      blocksize:         Optional[int] = None,
                      ) -> None:
         """Plot 2D mean free energy surface with a confidence interval"""
+        import scipy.stats.norm
 
         logger.info('Plotting 2D FES')
 
@@ -1588,7 +1589,7 @@ class Metadynamics:
         with warnings.catch_warnings():
             warnings.filterwarnings('ignore',
                                     message='invalid value encountered in multiply')
-            confidence_interval = norm.interval(confidence_level,
+            confidence_interval = scipy.stats.norm.interval(confidence_level,
                                                 loc=mean_fes,
                                                 scale=fes_error)
 

--- a/mlptrain/sampling/metadynamics.py
+++ b/mlptrain/sampling/metadynamics.py
@@ -1496,7 +1496,7 @@ class Metadynamics:
                      blocksize:         Optional[int] = None,
                      ) -> None:
         """Plot 1D mean free energy surface with a confidence interval"""
-        import scipy.stats.norm
+        import scipy.stats
 
         logger.info('Plotting 1D FES')
 
@@ -1555,7 +1555,7 @@ class Metadynamics:
                      blocksize:         Optional[int] = None,
                      ) -> None:
         """Plot 2D mean free energy surface with a confidence interval"""
-        import scipy.stats.norm
+        import scipy.stats
 
         logger.info('Plotting 2D FES')
 

--- a/mlptrain/sampling/plumed.py
+++ b/mlptrain/sampling/plumed.py
@@ -1,7 +1,6 @@
 import os
 import mlptrain
 import numpy as np
-import matplotlib.pyplot as plt
 from typing import Sequence, List, Tuple, Dict, Optional, Union
 from copy import deepcopy
 from ase import units as ase_units
@@ -1112,6 +1111,7 @@ def plot_cv_versus_time(filename:    str,
                      multiple plots of the same CVs are generated in the same
                      directory
     """
+    import matplotlib.pyplot as plt
 
     with open(filename, 'r') as f:
         header = f.readlines()[0]
@@ -1181,6 +1181,8 @@ def plot_cv1_and_cv2(filenames:   Sequence[str],
                      multiple plots of the same CVs are generated in the same
                      directory
     """
+
+    import matplotlib.pyplot as plt
 
     cvs_names, cvs_arrays = [], []
 

--- a/mlptrain/sampling/umbrella.py
+++ b/mlptrain/sampling/umbrella.py
@@ -4,7 +4,6 @@ import re
 import time
 import glob
 import numpy as np
-import matplotlib.pyplot as plt
 from scipy.optimize import curve_fit
 from scipy.integrate import simpson
 from typing import Optional, List, Callable, Tuple
@@ -207,6 +206,8 @@ class _Window:
     def _plot_gaussian(self, hist, bin_centres) -> None:
         """Fit a Gaussian to a histogram of data and plot the result"""
 
+        import matplotlib.pyplot as plt
+
         gaussian = _FittedGaussian()
 
         try:
@@ -246,6 +247,8 @@ class _Window:
 
             plot_gaussian:
         """
+        import matplotlib.pyplot as plt
+
         hist, bin_edges = np.histogram(self._obs_zetas,
                                        density=False,
                                        bins=np.linspace(min_zeta - 0.1*abs(min_zeta),
@@ -838,6 +841,7 @@ def _plot_and_save_free_energy(free_energies,
 
         zetas: Values of the reaction coordinate
     """
+    import matplotlib.pyplot as plt
 
     free_energies = convert_ase_energy(energy_array=free_energies, units=units)
 

--- a/mlptrain/system.py
+++ b/mlptrain/system.py
@@ -3,7 +3,6 @@ import autode
 import numpy as np
 from typing import Union, Sequence, List
 from scipy.spatial.distance import cdist
-from scipy.stats import special_ortho_group
 from mlptrain.configurations import Configuration, ConfigurationSet
 from mlptrain.log import logger
 from mlptrain.box import Box
@@ -205,6 +204,8 @@ class System:
     @staticmethod
     def _rotate_randomly(molecule) -> None:
         """Rotate a molecule randomly around it's centroid"""
+        from scipy.stats import special_ortho_group
+
         logger.info(f'Rotating {molecule.name} about its centroid')
 
         coords, centroid = molecule.coordinates, molecule.centroid


### PR DESCRIPTION
This speeds up import time of the mlptrain package by 80ms on my machine (from 610ms to 530ms).

The rest of the import time comes from the `autode` package. There are some easy wins to make as well, such as not importing `matplotlib.pyplot` until needed.

EDIT: `mlptrain` uses an old autode v1.1, so perhaps things are different in the later versions.