### PR TITLE
Add ruff format commit to .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,1 @@
+a5e89e407dd5b4ac988138af6870262d3a9e43fa # apply ruff formatter


### PR DESCRIPTION
This tells git and GitHub that it should ignore the commit from #85 when running `git blame`.

GitHub should pick this up automatically. For local development, put the following into your `~/.gitconfig`

```
[blame]
  ignoreRevsFile = .git-blame-ignore-revs
```