### PR TITLE
Fixes bug that prevents AL from running

### DIFF
--- a/mlptrain/sampling/md_openmm.py
+++ b/mlptrain/sampling/md_openmm.py
@@ -133,7 +133,14 @@ def run_mlp_md_openmm(
             'The OpenMM backend only supports the use of the MACE potential.'
         )
 
-    if any([fbond_energy, bbond_energy, bias, 'constraints' in kwargs]):
+    if any(
+        [
+            fbond_energy,
+            bbond_energy,
+            bias,
+            kwargs['constraints'] if 'constraints' in kwargs else None,
+        ]
+    ):
         raise NotImplementedError(
             "The OpenMM backend does not support the use of the 'bias', "
             "'fbond_energy', 'bbond_energy', or 'constraints' arguments."


### PR DESCRIPTION
This PR fixes a bug introduced in #87 that prevented AL from running when `constraints` was set to `None` as a kwarg.