### PR TITLE
Clean cache after MACE training

### DIFF
--- a/mlptrain/potentials/mace/mace.py
+++ b/mlptrain/potentials/mace/mace.py
@@ -2,6 +2,7 @@ import ase
 import mlptrain
 import argparse
 import os
+import gc
 import ast
 import time
 import shutil
@@ -120,6 +121,10 @@ class MACE(MLPotential):
         self._reset_train_objs()
 
         os.remove(f'{self.name}_data.xyz')
+
+        gc.collect()
+        torch.cuda.empty_cache()
+
         return None
 
     @property


### PR DESCRIPTION
Cleans CUDA cache before active learning loop to avoid CUDA out-of-memory error. 