### PR TITLE
Add basic Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+---
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      gha-dependencies:
+        patterns:
+          - '*'

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+env:
+  FORCE_COLOR: 1
+
 jobs:
   pre-commit:
     env:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -6,6 +6,9 @@ on:
     branches: [main]
   pull_request:
 
+env:
+  FORCE_COLOR: 1
+
 jobs:
   test:
     name: GAP (${{ matrix.python-version }}, ${{ matrix.os }})


### PR DESCRIPTION
This will allow Dependabot to submit PRs whenever a new GitHub Actions version is released
(such as updating `actions/checkout@v4` to `actions/checkout@v5` in GHA workflow files)

These PRs will have at most a monthly cadence so shouldn't be too noisy.