### PR TITLE
Pin libgfortran version

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,6 +5,7 @@ channels:
   - conda-forge
 dependencies:
   - python=3.9
+  - libgfortran=14.*
   - pip
   - pre-commit
   - ase

--- a/environment_ace.yml
+++ b/environment_ace.yml
@@ -5,6 +5,7 @@ channels:
   - conda-forge
 dependencies:
   - python=3.9
+  - libgfortran=14.*
   - pip
   - pre-commit
   - ase

--- a/environment_mace.yml
+++ b/environment_mace.yml
@@ -7,6 +7,7 @@ channels:
 dependencies:
   - python=3.9
   - pip
+  - libgfortran=14.*
   - pre-commit
   - ase
   - autode=1.3.3


### PR DESCRIPTION
Pinning libgfortran to 14.*, following the issue in xtb described in https://github.com/grimme-lab/xtb/issues/1277 and solution in https://github.com/duartegroup/autodE/pull/381
This fixes tests using xtb in CI. 

This will be resolved in the new version of xtb.