### PR TITLE
fix plot: support Matplotlib 3.10+

### DIFF
--- a/environment_mace.yml
+++ b/environment_mace.yml
@@ -14,7 +14,7 @@ dependencies:
   - coloredlogs
   - cython
   - dscribe=2.0
-  - matplotlib-base
+  - matplotlib-base>=3.9.0
   - numpy
   - pytest=8
   - pytest-cov=5

--- a/mlptrain/sampling/metadynamics.py
+++ b/mlptrain/sampling/metadynamics.py
@@ -1784,10 +1784,8 @@ class Metadynamics:
             else:
                 ax.set_ylabel(f'{cv2.name}')
 
-        for c in mean_contourf.collections:
-            c.set_edgecolor('face')
-        for c in std_error_contourf.collections:
-            c.set_edgecolor('face')
+        mean_contourf.set_edgecolor('face')
+        std_error_contourf.set_edgecolor('face')
 
         fig.tight_layout()
 


### PR DESCRIPTION
Due to "The collections attribute was deprecated in Matplotlib 3.8 and will be removed two minor releases later", the changes are made to metadynamics.py to support plotting when Matplotlib version is 3.10. The version of matplotlib is also added to the requirements.