### PR TITLE
Specify validation dataset

### DIFF
--- a/mlptrain/potentials/_base.py
+++ b/mlptrain/potentials/_base.py
@@ -26,24 +26,32 @@ class MLPotential(ABC):
         self.system = system
 
         self._training_data = mlt.ConfigurationSet()
+        self._validation_data = None
         self.atomic_energies = {}
 
     def train(
-        self, configurations: Optional['mlt.ConfigurationSet'] = None
+        self,
+        train_configs: Optional['mlt.ConfigurationSet'] = None,
+        valid_configs: Optional['mlt.ConfigurationSet'] = None,
     ) -> None:
         """
         Train this potential on a set of configurations
 
         -----------------------------------------------------------------------
         Arguments:
-            configurations: Set of configurations to train on, if None then
+            train_configs: Set of configurations to train on, if None then
                             will use self._training_data
+            valid_configs: Set of configurations to validate with; if None then
+                            will use a random split of training data
 
         Raises:
             (RuntimeError):
         """
-        if configurations is not None:
-            self._training_data = configurations
+        if train_configs is not None:
+            self._training_data = train_configs
+
+        if valid_configs is not None:
+            self._validation_data = valid_configs
 
         if len(self.training_data) == 0:
             raise RuntimeError(
@@ -136,7 +144,7 @@ class MLPotential(ABC):
 
     @training_data.setter
     def training_data(self, value: Optional['mlt.ConfigurationSet']):
-        """Set the training date for this MLP"""
+        """Set the training data for this MLP"""
 
         if value is None:
             self._training_data.clear()

--- a/mlptrain/potentials/_base.py
+++ b/mlptrain/potentials/_base.py
@@ -26,7 +26,7 @@ class MLPotential(ABC):
         self.system = system
 
         self._training_data = mlt.ConfigurationSet()
-        self._validation_data = None
+        # self._validation_data = None
         self.atomic_energies = {}
 
     def train(

--- a/mlptrain/potentials/mace/mace.py
+++ b/mlptrain/potentials/mace/mace.py
@@ -270,8 +270,6 @@ class MACE(MLPotential):
                 config.box = mlt.box.Box([100, 100, 100])
 
         self.training_data.save_xyz(filename=f'{self.name}_data.xyz')
-        if self._validation_data is not None:
-            self._validation_data.save_xyz(filename=f'{self.name}_valid.xyz')
 
         start_time = time.perf_counter()
 
@@ -282,10 +280,7 @@ class MACE(MLPotential):
         logger.info(f'MACE training ran in {delta_time / 60:.1f} m.')
 
         os.remove(f'{self.name}_data.xyz')
-
-        if self._validation_data is not None and os.path.exists(
-            f'{self.name}_valid.xyz'
-        ):
+        if os.path.exists(f'{self.name}_valid.xyz'):
             os.remove(f'{self.name}_valid.xyz')
 
         gc.collect()

--- a/mlptrain/potentials/mace/mace.py
+++ b/mlptrain/potentials/mace/mace.py
@@ -262,6 +262,37 @@ class MACE(MLPotential):
 
         self.training_data.save_xyz(filename=f'{self.name}_data.xyz')
 
+        # start patch
+        args = self.args
+
+        valid_filename = f'{self.name}_valid.xyz'
+        wrote_valid = False
+
+        # If the wrapper has a validation set attached, save it and tell MACE to use it
+        if (
+            hasattr(self, '_validation_data')
+            and getattr(self, '_validation_data') is not None
+        ):
+            try:
+                # only use non-empty validation_data
+                if len(self._validation_data) > 0:
+                    self._validation_data.save_xyz(filename=valid_filename)
+                    wrote_valid = True
+                    # Tell the MACE args to use the valid file instead of a fraction
+                    # parsed args is a Namespace so set attributes directly:
+                    setattr(args, 'valid_file', valid_filename)
+                    # Make sure MACE won't try to use valid_fraction in addition
+                    setattr(args, 'valid_fraction', 0.0)
+                    logger.info(
+                        f'Using explicit validation file: {valid_filename} '
+                        f'with {len(self._validation_data)} configs'
+                    )
+            except Exception as e:
+                logger.error(
+                    f'Failed to write or attach explicit validation set: {e}'
+                )
+        # end patch
+
         start_time = time.perf_counter()
 
         train_mace(self.args)
@@ -271,6 +302,14 @@ class MACE(MLPotential):
         logger.info(f'MACE training ran in {delta_time / 60:.1f} m.')
 
         os.remove(f'{self.name}_data.xyz')
+
+        # resume patch - cleanup temporary files
+        if wrote_valid and os.path.exists(valid_filename):
+            try:
+                os.remove(valid_filename)
+            except Exception:
+                logger.warning(f'Could not remove {valid_filename}')
+        # end patch again
 
         gc.collect()
         torch.cuda.empty_cache()

--- a/mlptrain/potentials/mace/mace.py
+++ b/mlptrain/potentials/mace/mace.py
@@ -270,36 +270,10 @@ class MACE(MLPotential):
                 config.box = mlt.box.Box([100, 100, 100])
 
         self.training_data.save_xyz(filename=f'{self.name}_data.xyz')
-
-        # start patch
-        # args = self.args
-
-        valid_filename = f'{self.name}_valid.xyz'
-        wrote_valid = False
-
-        # If the wrapper has a validation set attached, save it and tell MACE to use it
-        if (
-            hasattr(self, '_validation_data')
-            and getattr(self, '_validation_data') is not None
-        ):
-            try:
-                # only use non-empty validation_data
-                if len(self._validation_data) > 0:
-                    wrote_valid = True
-
-                    logger.info(
-                        f'Using explicit validation file: {valid_filename} '
-                        f'with {len(self._validation_data)} configs'
-                    )
-            except Exception as e:
-                logger.error(
-                    f'Failed to write or attach explicit validation set: {e}'
-                )
-        # end patch
+        if self._validation_data is not None:
+            self._validation_data.save_xyz(filename=f'{self.name}_valid.xyz')
 
         start_time = time.perf_counter()
-
-        # logger.info(f'About to call MACE: cwd={os.getcwd()}, train_file={getattr(self.args,"train_file",None)}, valid_file={getattr(self.args,"valid_file",None)}')
 
         train_mace(self.args)
 
@@ -309,13 +283,10 @@ class MACE(MLPotential):
 
         os.remove(f'{self.name}_data.xyz')
 
-        # resume patch - cleanup temporary files
-        if wrote_valid and os.path.exists(valid_filename):
-            try:
-                os.remove(valid_filename)
-            except Exception:
-                logger.warning(f'Could not remove {valid_filename}')
-        # end patch again
+        if self._validation_data is not None and os.path.exists(
+            f'{self.name}_valid.xyz'
+        ):
+            os.remove(f'{self.name}_valid.xyz')
 
         gc.collect()
         torch.cuda.empty_cache()

--- a/mlptrain/potentials/mace/mace.py
+++ b/mlptrain/potentials/mace/mace.py
@@ -280,9 +280,9 @@ class MACE(MLPotential):
                     wrote_valid = True
                     # Tell the MACE args to use the valid file instead of a fraction
                     # parsed args is a Namespace so set attributes directly:
-                    setattr(args, 'valid_file', valid_filename)
+                    setattr(args, '--valid_file', valid_filename)
                     # Make sure MACE won't try to use valid_fraction in addition
-                    setattr(args, 'valid_fraction', 0.0)
+                    setattr(args, '--valid_fraction', 0.0)
                     logger.info(
                         f'Using explicit validation file: {valid_filename} '
                         f'with {len(self._validation_data)} configs'

--- a/mlptrain/potentials/mace/mace.py
+++ b/mlptrain/potentials/mace/mace.py
@@ -89,19 +89,22 @@ class MACE(MLPotential):
 
     @property
     def valid_fraction(self) -> float:
-        """Fraction of the whole dataset to be used as validation set"""
-        _min_dataset = -(1 // -Config.mace_params['valid_fraction'])
-
-        if self.n_train == 1:
-            raise ValueError(
-                'MACE training requires at least ' '2 configurations'
-            )
-        elif self.n_train >= _min_dataset:
-            return Config.mace_params['valid_fraction']
+        """Fraction of the training dataset to be used as validation set"""
+        if self._validation_data is not None:
+            return 0.0  # Pass --valid_fraction = 0 to args if a separate validation dataset has been specified
         else:
-            # Valid fraction which sets at least 1 datapoint for validation
-            _unrounded_valid_fraction = 1 / self.n_train
-            return -((_unrounded_valid_fraction * 100) // -1) / 100
+            _min_dataset = -(1 // -Config.mace_params['valid_fraction'])
+
+            if self.n_train == 1:
+                raise ValueError(
+                    'MACE training requires at least ' '2 configurations'
+                )
+            elif self.n_train >= _min_dataset:
+                return Config.mace_params['valid_fraction']
+            else:
+                # Valid fraction which sets at least 1 datapoint for validation
+                _unrounded_valid_fraction = 1 / self.n_train
+                return -((_unrounded_valid_fraction * 100) // -1) / 100
 
     @property
     def batch_size(self) -> int:

--- a/mlptrain/potentials/mace/mace.py
+++ b/mlptrain/potentials/mace/mace.py
@@ -223,6 +223,12 @@ class MACE(MLPotential):
         if Config.mace_params['cueq']:
             args_list.append('--enable_cueq=True')
 
+        if getattr(self, '_validation_data', None) is not None:
+            valid_filename = f'{self.name}_valid.xyz'
+            self._validation_data.save_xyz(filename=valid_filename)
+            args_list.append(f'--valid_file={valid_filename}')
+            args_list.append('--valid_fraction=0.0')
+
         args = tools.build_default_arg_parser().parse_args(args_list)
         return args
 
@@ -263,7 +269,7 @@ class MACE(MLPotential):
         self.training_data.save_xyz(filename=f'{self.name}_data.xyz')
 
         # start patch
-        args = self.args
+        # args = self.args
 
         valid_filename = f'{self.name}_valid.xyz'
         wrote_valid = False
@@ -276,13 +282,8 @@ class MACE(MLPotential):
             try:
                 # only use non-empty validation_data
                 if len(self._validation_data) > 0:
-                    self._validation_data.save_xyz(filename=valid_filename)
                     wrote_valid = True
-                    # Tell the MACE args to use the valid file instead of a fraction
-                    # parsed args is a Namespace so set attributes directly:
-                    setattr(args, '--valid_file', valid_filename)
-                    # Make sure MACE won't try to use valid_fraction in addition
-                    setattr(args, '--valid_fraction', 0.0)
+
                     logger.info(
                         f'Using explicit validation file: {valid_filename} '
                         f'with {len(self._validation_data)} configs'
@@ -294,6 +295,8 @@ class MACE(MLPotential):
         # end patch
 
         start_time = time.perf_counter()
+
+        # logger.info(f'About to call MACE: cwd={os.getcwd()}, train_file={getattr(self.args,"train_file",None)}, valid_file={getattr(self.args,"valid_file",None)}')
 
         train_mace(self.args)
 

--- a/mlptrain/potentials/mace/mace.py
+++ b/mlptrain/potentials/mace/mace.py
@@ -90,8 +90,14 @@ class MACE(MLPotential):
     @property
     def valid_fraction(self) -> float:
         """Fraction of the training dataset to be used as validation set"""
-        if self._validation_data is not None:
-            return 0.0  # Pass --valid_fraction = 0 to args if a separate validation dataset has been specified
+
+        if getattr(self, '_validation_data', None) is not None:
+            valid_filename = f'{self.name}_valid.xyz'
+            self._validation_data.save_xyz(filename=valid_filename)
+            return 0.0
+        #            args_list.append(f'--valid_file={valid_filename}')
+        #            args_list.append('--valid_fraction=0.0')
+
         else:
             _min_dataset = -(1 // -Config.mace_params['valid_fraction'])
 
@@ -227,10 +233,11 @@ class MACE(MLPotential):
             args_list.append('--enable_cueq=True')
 
         if getattr(self, '_validation_data', None) is not None:
-            valid_filename = f'{self.name}_valid.xyz'
-            self._validation_data.save_xyz(filename=valid_filename)
-            args_list.append(f'--valid_file={valid_filename}')
-            args_list.append('--valid_fraction=0.0')
+            # These has now been done in self.valid_fraction():
+            # valid_filename = f'{self.name}_valid.xyz'
+            # self._validation_data.save_xyz(filename=valid_filename)
+            # args_list.append('--valid_fraction=0.0')
+            args_list.append(f'--valid_file={self.name}_valid.xyz')
 
         args = tools.build_default_arg_parser().parse_args(args_list)
         return args


### PR DESCRIPTION
When calling MACE.train(), rather than taking a single input ConfigurationSet to be the training data, and then taking a random 10% (by default - set as --valid_fraction) of that dataset as a validation set; now there's the option to have a second ConfigSet as input which will be the validation set of the potential. 

Example use case: if there are two or more distinct datasets being used to train the model: you can (beforehand) perform a stratified split of these, to ensure an even split of these datasets in the training vs validation datasets, so that the model can learn from both effectively.