### PR TITLE
Added wandb integration in MACE training

### DIFF
--- a/environment_mace.yml
+++ b/environment_mace.yml
@@ -33,3 +33,4 @@ dependencies:
     - cuequivariance==0.1.0
     - cuequivariance-torch==0.1.0
     - cuequivariance-ops-torch-cu11==0.1.0
+    - wandb

--- a/mlptrain/config.py
+++ b/mlptrain/config.py
@@ -84,6 +84,9 @@ class _ConfigClass:
         'dtype': 'float32',
         'pt_train': None,
         'cueq': False,
+        'wandb': False,
+        'wandb_project': None,
+        'wandb_name': None,
     }
 
     # --------------------- Internal properties ---------------------------

--- a/mlptrain/potentials/mace/mace.py
+++ b/mlptrain/potentials/mace/mace.py
@@ -224,6 +224,15 @@ class MACE(MLPotential):
         if Config.mace_params['cueq']:
             args_list.append('--enable_cueq=True')
 
+        if Config.mace_params['wandb']:
+            args_list.append('--wandb')
+            args_list.append(
+                f"--wandb_project={Config.mace_params['wandb_project']}"
+            )
+            args_list.append(
+                f"--wandb_name={Config.mace_params['wandb_name']}"
+            )
+
         args = tools.build_default_arg_parser().parse_args(args_list)
         return args
 


### PR DESCRIPTION
Added wandb integration into the training of MACE potentials, allows visualisation of error curves. Required that you create an account at wandb.ai and paste your api key when prompted on the first activation. Defaults to false as to not prompt users who do not wish to use wandb. 