### PR TITLE
Fix MACE log doubling

### DIFF
--- a/mlptrain/potentials/mace/mace.py
+++ b/mlptrain/potentials/mace/mace.py
@@ -286,6 +286,7 @@ class MACE(MLPotential):
 
         train_mace(self.args)
 
+        # Remove MACE root logging handlers
         remove_root_logging_handlers()
 
         # Restore our root logging handlers

--- a/mlptrain/potentials/mace/mace.py
+++ b/mlptrain/potentials/mace/mace.py
@@ -281,6 +281,7 @@ class MACE(MLPotential):
 
         start_time = time.perf_counter()
 
+        # Remove mlp-train root logging handlers, but save for later
         our_logging_handlers = remove_root_logging_handlers()
 
         train_mace(self.args)

--- a/mlptrain/potentials/mace/mace.py
+++ b/mlptrain/potentials/mace/mace.py
@@ -255,6 +255,16 @@ class MACE(MLPotential):
         import torch
         from mace.cli.run_train import run as train_mace
 
+        def remove_root_logging_handlers() -> list[logging.Handler]:
+            """Remove and return root logging handlers before calling MACE"""
+
+            # Remove existing logging as MACE creates it's own loggers
+            root_logger = logging.getLogger()
+            root_logging_handlers = list(root_logger.handlers)
+            for handler in root_logging_handlers:
+                root_logger.removeHandler(handler)
+            return root_logging_handlers
+
         n_cores = n_cores if n_cores is not None else Config.n_cores
         os.environ['OMP_NUM_THREADS'] = str(n_cores)
         logger.info(
@@ -271,7 +281,16 @@ class MACE(MLPotential):
 
         start_time = time.perf_counter()
 
+        our_logging_handlers = remove_root_logging_handlers()
+
         train_mace(self.args)
+
+        remove_root_logging_handlers()
+
+        # Restore our root logging handlers
+        root_logger = logging.getLogger()
+        for handler in our_logging_handlers:
+            root_logger.addHandler(handler)
 
         delta_time = time.perf_counter() - start_time
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,10 @@ banned-module-level-imports = ["mace", "openmm", "openmmml", "sklearn", "torch"]
 
 [tool.pytest.ini_options]
 addopts = "--cov-report term --cov-report xml"
+filterwarnings = [
+  'ignore:You are using `torch.load`:FutureWarning:e3nn|mace|openmmml:',
+  'ignore:The TorchScript type system:UserWarning:torch:',
+]
 
 [tool.ty.terminal]
 # Error if ty emits any warning-level diagnostics.

--- a/tests/test_mace.py
+++ b/tests/test_mace.py
@@ -2,12 +2,12 @@
 
 import importlib.util
 import logging
-from mlptrain.log import logger as mlp_logger
 
 import pytest
 
 import mlptrain
 from mlptrain.box import Box
+from mlptrain.log import logger as mlp_logger
 from mlptrain.utils import work_in_tmp_dir
 
 # Only run these tests if MACE is installed
@@ -19,16 +19,13 @@ pytestmark = pytest.mark.skipif(
 
 @pytest.fixture
 def mock_mace_run_train(monkeypatch, tmp_path):
-    """Fixture to mock mace.cli.run_train function"""
+    """Fixture to mock mace.cli.run_train.run function"""
 
     def train_mace_mock(args) -> None:
         # We obviously don't run any training,
         # but we do setup MACE logging in a similar way as the real train function
         # by calling mace.tools.setup_logger
-        try:
-            from mace.tools import setup_logger
-        except ImportError:
-            return
+        from mace.tools import setup_logger
 
         logging.info('mock_mace_run_train: Before setup_logger')
         setup_logger(directory=tmp_path)
@@ -41,8 +38,11 @@ def mock_mace_run_train(monkeypatch, tmp_path):
     )
 
 
-# This test uses the pytest caplog fixture, see:
+# This is a regression test for the log doubling issue.
+# It uses the pytest caplog fixture, see:
 # https://docs.pytest.org/en/stable/how-to/logging.html#caplog-fixture
+# To see the log messages during testing run:
+# $ pytest --log-cli-level=INFO tests/test_mace.py::test_train_logging
 @work_in_tmp_dir()
 def test_train_logging(
     caplog, mock_mace_run_train, h2, h2_configuration, h2o_configuration
@@ -57,7 +57,7 @@ def test_train_logging(
 
     caplog.clear()
     mlp = MACE(name='test', system=system)
-    # We should print MACE version in the constructor
+    # Check that we print MACE version in the constructor
     assert caplog.records[0].message.startswith('MACE version:')
 
     mlp.atomic_energies = {'H': -0.5}

--- a/tests/test_mace.py
+++ b/tests/test_mace.py
@@ -1,0 +1,85 @@
+"""Tests for mlptrain.potentials.mace module"""
+
+import importlib.util
+import logging
+from mlptrain.log import logger as mlp_logger
+
+import pytest
+
+import mlptrain
+from mlptrain.box import Box
+from mlptrain.utils import work_in_tmp_dir
+
+# Only run these tests if MACE is installed
+pytestmark = pytest.mark.skipif(
+    not importlib.util.find_spec('mace'),
+    reason='requires MACE',
+)
+
+
+@pytest.fixture
+def mock_mace_run_train(monkeypatch, tmp_path):
+    """Fixture to mock mace.cli.run_train function"""
+
+    def train_mace_mock(args) -> None:
+        # We obviously don't run any training,
+        # but we do setup MACE logging in a similar way as the real train function
+        # by calling mace.tools.setup_logger
+        try:
+            from mace.tools import setup_logger
+        except ImportError:
+            return
+
+        logging.info('mock_mace_run_train: Before setup_logger')
+        setup_logger(directory=tmp_path)
+        logging.info('mock_mace_run_train: After setup_logger')
+
+    # from mace.cli.run_train import run as train_mace
+    monkeypatch.setattr(
+        'mace.cli.run_train.run',
+        train_mace_mock,
+    )
+
+
+# This test uses the pytest caplog fixture, see:
+# https://docs.pytest.org/en/stable/how-to/logging.html#caplog-fixture
+@work_in_tmp_dir()
+def test_train_logging(
+    caplog, mock_mace_run_train, h2, h2_configuration, h2o_configuration
+):
+    from mlptrain.potentials import MACE
+
+    system = mlptrain.System(h2, box=Box([10, 10, 10]))
+    h2_configuration.energy.true = -0.5
+    h2o_configuration.energy.true = -1.0
+
+    confs = mlptrain.ConfigurationSet(h2_configuration, h2o_configuration)
+
+    caplog.clear()
+    mlp = MACE(name='test', system=system)
+    # We should print MACE version in the constructor
+    assert caplog.records[0].message.startswith('MACE version:')
+
+    mlp.atomic_energies = {'H': -0.5}
+
+    caplog.clear()
+
+    mlp.train(confs)
+
+    num_messages = len(caplog.records)
+    assert num_messages != 0
+
+    # Make sure we print the nodename at the start of training
+    assert caplog.records[0].message.startswith('Training on nodename')
+
+    # Make sure that the number of log messages is the same on second call
+    caplog.clear()
+    mlp.train(confs)
+    assert len(caplog.records) == num_messages
+
+    # Make sure logging is not doubled
+    caplog.clear()
+    mlp_logger.info('test info from mlp logger')
+    logging.info('test info from root logger')
+
+    assert len(caplog.records) == 2


### PR DESCRIPTION
It turns out that the problem with the spurious multiplying log messages is due the mace bug (specifically in its `setup_logger` function). 

Here's a simple reproducer of the logging issue that does not involve mlptrain at all:

```python
import logging
import warnings
with warnings.catch_warnings():
    warnings.simplefilter('ignore')
    from mace.tools import setup_logger

logging.warning("First message before calling MACE")

setup_logger(directory="/tmp/mace_logging/")

print()
logging.warning("Second message, after calling MACE")

setup_logger(directory="/tmp/mace_logging/")

print()
logging.warning("Third message, after calling MACE again")
```

Which produces the following output:

```console
WARNING:root:First message before calling MACE

WARNING:root:Second message, after calling MACE
2026-04-07 15:04:19.252 WARNING: Second message, after calling MACE

WARNING:root:Third message, after calling MACE again
2026-04-07 15:04:19.252 WARNING: Third message, after calling MACE again
2026-04-07 15:04:19.252 WARNING: Third message, after calling MACE again
```

I am going to report the bug upstream, but in this PR I am proposing a workaround.


The added unit test unfortunately does not work: it passes also on main branch (even without the fix). I think this is because pytest somehow messes with the logging system so the problem does not reproduce. I think the test is still useful though as it tests a previously untested function so I kept it in. I have tested manually that the fix works.