### PR TITLE
feat: Add Docker/Singularity container build and CI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+Dockerfile

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,81 @@
+# build docker image and push to github registry
+name: Build and Push Container Images
+on:
+  push:
+    branches:
+      - main
+      - jl/docker
+    paths:
+      - 'Dockerfile'
+      - '.github/workflows/docker.yml'
+      - 'mlptrain/**'
+      - 'environment*.yml'
+      - 'README.md'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'Dockerfile'
+      - '.github/workflows/docker.yml'
+      - 'mlptrain/**'
+      - 'environment*.yml'
+      - 'README.md'
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  DOCKER_IMAGE_SHA: ghcr.io/${{ github.repository_owner }}/mlp-train:${{ github.sha }}
+  DOCKER_IMAGE_LATEST: ghcr.io/${{ github.repository_owner }}/mlp-train:latest
+  SIF_IMAGE_SHA: oras://ghcr.io/${{ github.repository_owner }}/mlp-train-sif:${{ github.sha }}
+  SIF_IMAGE_LATEST: oras://ghcr.io/${{ github.repository_owner }}/mlp-train-sif:latest
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        if: github.event_name == 'push'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          push: ${{ github.event_name == 'push' }}
+          tags: |
+            ${{ env.DOCKER_IMAGE_SHA }}
+            ${{ env.DOCKER_IMAGE_LATEST }}
+
+      - name: Set up Apptainer
+        if: github.event_name == 'push'
+        uses: eWaterCycle/setup-apptainer@v2
+        with:
+          apptainer-version: 1.4.5
+
+      - name: Build and push Singularity image
+        if: github.event_name == 'push'
+        env:
+          APPTAINER_DOCKER_USERNAME: ${{ github.actor }}
+          APPTAINER_DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+          APPTAINER_TMPDIR: ${{ runner.temp }}/apptainer-tmp
+          APPTAINER_CACHEDIR: ${{ runner.temp }}/apptainer-cache
+          DOCKER_SOURCE_IMAGE: docker://${{ env.DOCKER_IMAGE_SHA }}
+        run: |
+          mkdir -p "${APPTAINER_TMPDIR}" "${APPTAINER_CACHEDIR}"
+
+          apptainer build mlp-train.sif "${DOCKER_SOURCE_IMAGE}"
+          apptainer push --allow-unsigned mlp-train.sif "${SIF_IMAGE_SHA}"
+          apptainer push --allow-unsigned mlp-train.sif "${SIF_IMAGE_LATEST}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+FROM mambaorg/micromamba:2.2.0-cuda12.2.2-ubuntu22.04
+
+USER root
+WORKDIR /app
+
+ENV CONDA_ENV_NAME=mlptrain-mace
+ENV CONDA_ENV_FILE=environment_mace.yml
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install system dependencies
+RUN apt-get update && \
+    apt-get install -y nvidia-driver-535-server \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install dependencies and MACE
+COPY ./${CONDA_ENV_FILE} /app/${CONDA_ENV_FILE}
+RUN micromamba env create -n "${CONDA_ENV_NAME}" --file /app/${CONDA_ENV_FILE} && \
+    micromamba clean -a
+
+# Install mlptrain
+COPY . /app
+
+RUN micromamba run -n ${CONDA_ENV_NAME} python -m pip install -e . && \
+    micromamba clean -a
+
+# Had to hardcode the environment name due to docker limitations
+ENTRYPOINT ["/usr/bin/micromamba", "run", "-n", "mlptrain-mace"]
+CMD ["python", "-m", "pytest"]

--- a/examples/container_usage/README.md
+++ b/examples/container_usage/README.md
@@ -1,0 +1,116 @@
+# Container Usage 
+
+A dockerfile, and [pre-built
+image](docker://ghcr.io/duartegroup/mlp-train:latest), are provided with
+mlp-train to provide a funcitoning installation out of the box. Currently the
+dockerfile utilises the `environment_mace.yml` to install dependencies into a
+micromamba (i.e. conda) environment called `mlptrain-mace`, as per the
+`install_mace.sh` installation script, but this is liable to change as the
+installation process evolves. 
+
+### Docker
+
+The docker image should be usable as-is, simply pull it from the github
+container registry with the command:
+
+``` bash
+docker pull ghcr.io/duartegroup/mlp-train:latest
+```
+
+and then run the usual way, either interactively: 
+
+``` bash
+docker run -it --gpus all --name mlp-train-container ghcr.io/duartegroup/mlp-train:latest /bin/bash
+```
+
+or with a specified command by removing `-it` and replacing `/bin/bash` with the
+command you'd like to use. Note that you will likely need to mount whatever
+specific script you'd like to run onto the container so the container can see
+it, see below for an example. Alternatively you could build on top of the docker
+image using a `FROM` command in a custom dockerfile, though that is beyond the
+scope of this guide. 
+
+
+### Singularity/Apptainer
+
+We also publish a pre-built Singularity/Apptainer SIF image to GHCR. Pull it with:
+
+``` bash
+apptainer pull mlp-train.sif oras://ghcr.io/duartegroup/mlp-train-sif:latest
+```
+
+Older versions can be pulled by replacing `latest` with the relevant commit hash.
+
+If, for whatever reason, that doesn't work, you could convert the docker image 
+manually instead. To do this, run:
+
+``` bash
+singularity build mlp-train.sif docker://ghcr.io/duartegroup/mlp-train:latest
+```
+
+which will pull the docker image and convert it into a singularity-friendly SIF
+file at `mlp-train.sif`. Note the prepended `docker://` on the image address to 
+tell singularity that it's a docker image, not a singularity one.
+
+If you'd then like to run this built image you can use something like:
+
+```bash
+singularity exec --nv mlp-train.sif /usr/bin/micromamba run -n mlptrain-mace python /app/examples/water.py
+```
+where the `water.py` script in this examples directory is run using the
+mlptrain-mace conda environment on the container.  
+
+Alternatively you can run the singularity image interactively with:
+
+```bash
+singularity shell --nv mlp-train.sif
+```
+
+and then run further commands on the container at your leisure. 
+
+
+## ARC Example Scripts
+
+This folder contains two example scripts for utilising the provided [docker
+image](docker://ghcr.io/duartegroup/mlp-train:latest) on an HPC system,
+consisting of:
+
+1. [A build script](singularity-build.sh), which builds the singularity image by
+   pulling the stored docker image in the github container registry and then
+   converting it into a `.sif` file, at some specified location. this is
+   submitted as a batch job as ARC's login nodes were _very_ slow to build,
+   presumably due to IO constraints. The environment variables
+   `SINGULARITY_TMPDIR` and `SINGULARITY_CACHEDIR` are set to local node memory
+   and the built `.sif` image is then copied to the user's `$DATA` directory,
+   which is ARC-specific but easily portable depending on the particular setup
+   of whichever HPC system you are using. 
+2. [A run script](singularity-run.sh), which runs the `.sif` image created by
+   the build script with singularity's `--nv` flag, which includes the necessary
+   nvidia drivers to properly utilise the GPU, as well as `mpirun` to utilise
+   however many cores/tasks have been specified. Other notable parts of the
+   singularity command include:
+    - `-B $DATA/mlp-train:/data`: binds/mounts a local direcory (in this case
+       `$DATA/mlp-train`) to a  directory on the container (`/data`), which in
+       this case contains the `water_mace.py` script we intend to run.
+    - `--pwd /data`: sets the workding directory of the container to this
+      mounted directory.
+    - `$DATA/singularity/mlp-train.sif`: selects the image built using the above
+      build script as the image to be run as a container
+    - `/usr/bin/micromamba run -n mlptrain-mace python /data/water_mace.py`:
+      runs the intended script (`water_mace.py`) with the micromamba environment
+      `mlptrain-mace` on the container 
+
+These are limted examples but should hopefully allow you to start creating your
+own scripts for your own purposes. 
+
+Note that the build script need only be re-run if mlp-train is updated.
+
+
+## Continuous Integration
+
+The docker image is built and pushed to the github container registry upon any
+push to a publishing branch which changes any of the relevant code for the
+dockerfile. CI also builds a Singularity/Apptainer SIF image from the
+commit-specific docker image and pushes it to GHCR. Older versions of either
+image, i.e. not latest, can be accessed with the commit hash of the desired
+commit.

--- a/examples/container_usage/singularity-build.sh
+++ b/examples/container_usage/singularity-build.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+#SBATCH --job-name=singularity-build
+#SBATCH --ntasks-per-node=4
+#SBATCH --nodes=1
+#SBATCH --time=12:00:00
+#SBATCH --partition=short
+
+SINGULARITY_CACHEDIR=$TMPDIR SINGULARITY_TMPDIR=$TMPDIR singularity build $SCRATCH/mlp-train.sif docker://ghcr.io/jackleland/mlp-train:latest
+
+rsync -a $SCRATCH/ $DATA/singularity/

--- a/examples/container_usage/singularity-run.sh
+++ b/examples/container_usage/singularity-run.sh
@@ -1,0 +1,23 @@
+#! /bin/bash
+
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=8
+#SBATCH --gres=gpu:1
+#SBATCH --partition=short
+#SBATCH --account=dtce-schmidt
+#SBATCH --time=02:00:00
+#SBATCH --mem-per-gpu=32G
+#SBATCH --job-name=mlp-train-gputest
+#SBATCH --output=logs/mlp-train-%A.out
+#SBATCH --error=logs/mlp-train-%A.err
+#SBATCH --mail-type=BEGIN,END
+#SBATCH --mail-user=jack.leland@dtc.ox.ac.uk
+
+module load OpenMPI
+
+nvidia-smi
+which singularity 
+singularity --version
+
+mpirun singularity exec --nv -B $DATA/mlp-train:/data --pwd /data $DATA/singularity/mlp-train.sif /usr/bin/micromamba run -n mlptrain-mace python /data/water_mace.py


### PR DESCRIPTION
Provides a containerised install so mlp-train + MACE runs out of the box, including on ARC via Singularity.

- Dockerfile building the MACE environment via micromamba.
- docker.yml workflow to build and push the image to GHCR.
- examples/container_usage/: README plus Singularity build/run scripts.

6 new files, no source changes.