### PR TITLE
fix: Deduplicate logging across MACE and ConfigurationSet

### DIFF
--- a/mlptrain/configurations/configuration_set.py
+++ b/mlptrain/configurations/configuration_set.py
@@ -119,7 +119,7 @@ class ConfigurationSet(list):
         """
         if len(self) == 0:
             raise ValueError(
-                'No lowest biased energy configuration in an ' 'empty set'
+                'No lowest biased energy configuration in an empty set'
             )
 
         true_energy = np.array(
@@ -145,7 +145,7 @@ class ConfigurationSet(list):
         """
         if len(self) == 0:
             raise ValueError(
-                'No lowest biased energy configuration in an ' 'empty set'
+                'No lowest biased energy configuration in an empty set'
             )
 
         true_energy = np.array(
@@ -234,7 +234,7 @@ class ConfigurationSet(list):
 
         if not self.allow_duplicates and value in self:
             logger.warning(
-                'Not appending configuration to set - already ' 'present'
+                'Not appending configuration to set - already present'
             )
             return
 
@@ -542,8 +542,7 @@ class ConfigurationSet(list):
 
         else:
             raise ValueError(
-                f'Cannot load {filename}. Must be either a '
-                f'.xyz or .npz file'
+                f'Cannot load {filename}. Must be either a .xyz or .npz file'
             )
 
         return None
@@ -608,8 +607,7 @@ class ConfigurationSet(list):
 
         elif len(n_cvs_set) != 1:
             logger.info(
-                'Number of CVs differ between configurations - '
-                'returning None'
+                'Number of CVs differ between configurations - returning None'
             )
             return None
 
@@ -665,13 +663,15 @@ class ConfigurationSet(list):
     ) -> Optional[np.ndarray]:
         """True or predicted forces. Returns a 3D np.ndarray."""
 
-        all_forces = []
-        for config in self:
-            if getattr(config.forces, kind) is None:
+        all_forces = [getattr(config.forces, kind) for config in self]
+        if all(force is None for force in all_forces):
+            if kind == 'true':
                 logger.warning(f'{kind} forces not defined - returning None')
-                return None
+            return None
 
-            all_forces.append(getattr(config.forces, kind))
+        if any(force is None for force in all_forces):
+            logger.warning(f'{kind} forces partially defined - returning None')
+            return None
 
         return np.array(all_forces, dtype=object)
 

--- a/mlptrain/configurations/configuration_set.py
+++ b/mlptrain/configurations/configuration_set.py
@@ -666,7 +666,7 @@ class ConfigurationSet(list):
         all_forces = [getattr(config.forces, kind) for config in self]
         if all(force is None for force in all_forces):
             if kind == 'true':
-                logger.warning(f'{kind} forces not defined - returning None')
+                logger.debug(f'{kind} forces not defined - returning None')
             return None
 
         if any(force is None for force in all_forces):

--- a/mlptrain/log.py
+++ b/mlptrain/log.py
@@ -1,10 +1,14 @@
 import logging
 import os
+from typing import Optional
 
 _LOGGING_FORMAT = '%(asctime)s %(name)s[%(process)d] %(levelname)s %(message)s'
+_LOGGER_NAME = 'mlptrain'
+_HANDLER_MARKER = '_mlptrain_handler'
 
 # Print year with only two digits
 _DATE_FORMAT = '%y-%m-%d %H:%M:%S'
+
 
 # Users can specify the logging level by setting the MLT_LOG_LEVEL environment variable before
 # running the python program. e.g. to only print warning message:
@@ -13,23 +17,65 @@ _DATE_FORMAT = '%y-%m-%d %H:%M:%S'
 #
 # Valid logging levels are defined as attributes of the logging module, see:
 # https://docs.python.org/3/library/logging.html#logging-levels
-ll = os.environ.get('MLT_LOG_LEVEL', default='INFO')
-try:
-    _level = getattr(logging, ll)
-except AttributeError:
-    _level = logging.INFO
-    print(f'Invalid value of MLT_LOG_LEVEL: "{ll}"')
-    print('Falling back to INFO level')
+def _log_level() -> int:
+    level_name = os.environ.get('MLT_LOG_LEVEL', default='INFO').upper()
+    try:
+        return getattr(logging, level_name)
+    except AttributeError:
+        print(f'Invalid value of MLT_LOG_LEVEL: "{level_name}"')
+        print('Falling back to INFO level')
+        return logging.INFO
 
-logging.basicConfig(level=_level, format=_LOGGING_FORMAT, datefmt=_DATE_FORMAT)
 
-logger = logging.getLogger('mlptrain')
-# Try and use colourful logs
-try:
-    import coloredlogs
+def _find_owned_handler(logger: logging.Logger) -> Optional[logging.Handler]:
+    for handler in logger.handlers:
+        if getattr(handler, _HANDLER_MARKER, False):
+            return handler
 
-    coloredlogs.install(
-        level=_level, logger=logger, fmt=_LOGGING_FORMAT, datefmt=_DATE_FORMAT
+    return None
+
+
+def _new_handler(logger: logging.Logger) -> logging.Handler:
+    before_handlers = list(logger.handlers)
+
+    # Try and use colourful logs
+    try:
+        import coloredlogs
+
+        coloredlogs.install(
+            level=logger.level,
+            logger=logger,
+            fmt=_LOGGING_FORMAT,
+            datefmt=_DATE_FORMAT,
+            reconfigure=False,
+        )
+        for handler in logger.handlers:
+            if handler not in before_handlers:
+                return handler
+    except ImportError:
+        pass
+
+    handler = logging.StreamHandler()
+    handler.setFormatter(
+        logging.Formatter(_LOGGING_FORMAT, datefmt=_DATE_FORMAT)
     )
-except ImportError:
-    pass
+    logger.addHandler(handler)
+    return handler
+
+
+def _configure_logger() -> logging.Logger:
+    logger = logging.getLogger(_LOGGER_NAME)
+    logger.setLevel(_log_level())
+    logger.propagate = False
+
+    handler = _find_owned_handler(logger)
+    if handler is None:
+        handler = _new_handler(logger)
+        setattr(handler, _HANDLER_MARKER, True)
+
+    handler.setLevel(logger.level)
+
+    return logger
+
+
+logger = _configure_logger()

--- a/mlptrain/log.py
+++ b/mlptrain/log.py
@@ -1,10 +1,8 @@
 import logging
 import os
-from typing import Optional
 
 _LOGGING_FORMAT = '%(asctime)s %(name)s[%(process)d] %(levelname)s %(message)s'
 _LOGGER_NAME = 'mlptrain'
-_HANDLER_MARKER = '_mlptrain_handler'
 
 # Print year with only two digits
 _DATE_FORMAT = '%y-%m-%d %H:%M:%S'
@@ -27,17 +25,7 @@ def _log_level() -> int:
         return logging.INFO
 
 
-def _find_owned_handler(logger: logging.Logger) -> Optional[logging.Handler]:
-    for handler in logger.handlers:
-        if getattr(handler, _HANDLER_MARKER, False):
-            return handler
-
-    return None
-
-
-def _new_handler(logger: logging.Logger) -> logging.Handler:
-    before_handlers = list(logger.handlers)
-
+def _add_handler(logger: logging.Logger) -> None:
     # Try and use colourful logs
     try:
         import coloredlogs
@@ -49,9 +37,7 @@ def _new_handler(logger: logging.Logger) -> logging.Handler:
             datefmt=_DATE_FORMAT,
             reconfigure=False,
         )
-        for handler in logger.handlers:
-            if handler not in before_handlers:
-                return handler
+        return
     except ImportError:
         pass
 
@@ -59,21 +45,15 @@ def _new_handler(logger: logging.Logger) -> logging.Handler:
     handler.setFormatter(
         logging.Formatter(_LOGGING_FORMAT, datefmt=_DATE_FORMAT)
     )
+    handler.setLevel(logger.level)
     logger.addHandler(handler)
-    return handler
 
 
 def _configure_logger() -> logging.Logger:
     logger = logging.getLogger(_LOGGER_NAME)
     logger.setLevel(_log_level())
     logger.propagate = False
-
-    handler = _find_owned_handler(logger)
-    if handler is None:
-        handler = _new_handler(logger)
-        setattr(handler, _HANDLER_MARKER, True)
-
-    handler.setLevel(logger.level)
+    _add_handler(logger)
 
     return logger
 

--- a/mlptrain/log.py
+++ b/mlptrain/log.py
@@ -17,15 +17,24 @@ _DATE_FORMAT = '%y-%m-%d %H:%M:%S'
 # https://docs.python.org/3/library/logging.html#logging-levels
 def _log_level() -> int:
     level_name = os.environ.get('MLT_LOG_LEVEL', default='INFO').upper()
-    try:
-        return getattr(logging, level_name)
-    except AttributeError:
+
+    # Not every upper case attribute of the logging module is a level, e.g.
+    # logging.BASIC_FORMAT is a string, so check the type rather than relying
+    # on getattr raising for unknown names
+    level = getattr(logging, level_name, None)
+    if not isinstance(level, int):
         print(f'Invalid value of MLT_LOG_LEVEL: "{level_name}"')
         print('Falling back to INFO level')
         return logging.INFO
 
+    return level
+
 
 def _add_handler(logger: logging.Logger) -> None:
+    # Configuring an already configured logger would duplicate every message
+    if logger.handlers:
+        return
+
     # Try and use colourful logs
     try:
         import coloredlogs

--- a/mlptrain/log.py
+++ b/mlptrain/log.py
@@ -17,17 +17,20 @@ _DATE_FORMAT = '%y-%m-%d %H:%M:%S'
 # https://docs.python.org/3/library/logging.html#logging-levels
 def _log_level() -> int:
     level_name = os.environ.get('MLT_LOG_LEVEL', default='INFO').upper()
-
-    # Not every upper case attribute of the logging module is a level, e.g.
-    # logging.BASIC_FORMAT is a string, so check the type rather than relying
-    # on getattr raising for unknown names
-    level = getattr(logging, level_name, None)
-    if not isinstance(level, int):
+    allowed_levels = (
+        'NOTSET',
+        'DEBUG',
+        'INFO',
+        'WARNING',
+        'ERROR',
+        'CRITICAL',
+    )
+    if level_name not in allowed_levels:
         print(f'Invalid value of MLT_LOG_LEVEL: "{level_name}"')
         print('Falling back to INFO level')
         return logging.INFO
 
-    return level
+    return getattr(logging, level_name)
 
 
 def _add_handler(logger: logging.Logger) -> None:

--- a/mlptrain/potentials/mace/mace.py
+++ b/mlptrain/potentials/mace/mace.py
@@ -57,7 +57,7 @@ class MACE(MLPotential):
             import mace.tools
 
         self.foundation = foundation
-        logging.info(f'MACE version: {mace.__version__}')
+        logger.info(f'MACE version: {mace.__version__}')
 
         mace.tools.set_seeds(345)
         mace.tools.set_default_dtype(str(Config.mace_params['dtype']))
@@ -255,6 +255,13 @@ class MACE(MLPotential):
         import torch
         from mace.cli.run_train import run as train_mace
 
+        def root_handler_key(handler: logging.Handler) -> tuple:
+            return (
+                type(handler),
+                getattr(handler, 'baseFilename', None),
+                getattr(handler, 'stream', None),
+            )
+
         def remove_root_logging_handlers() -> list[logging.Handler]:
             """Remove and return root logging handlers before calling MACE"""
 
@@ -264,6 +271,19 @@ class MACE(MLPotential):
             for handler in root_logging_handlers:
                 root_logger.removeHandler(handler)
             return root_logging_handlers
+
+        def restore_root_logging_handlers(
+            handlers: list[logging.Handler],
+        ) -> None:
+            """Restore root handlers without adding duplicate destinations."""
+            root_logger = logging.getLogger()
+            seen = {root_handler_key(h) for h in root_logger.handlers}
+            for handler in handlers:
+                key = root_handler_key(handler)
+                if key in seen:
+                    continue
+                root_logger.addHandler(handler)
+                seen.add(key)
 
         n_cores = n_cores if n_cores is not None else Config.n_cores
         os.environ['OMP_NUM_THREADS'] = str(n_cores)
@@ -284,15 +304,12 @@ class MACE(MLPotential):
         # Remove mlp-train root logging handlers, but save for later
         our_logging_handlers = remove_root_logging_handlers()
 
-        train_mace(self.args)
-
-        # Remove MACE root logging handlers
-        remove_root_logging_handlers()
-
-        # Restore our root logging handlers
-        root_logger = logging.getLogger()
-        for handler in our_logging_handlers:
-            root_logger.addHandler(handler)
+        try:
+            train_mace(self.args)
+        finally:
+            # Remove MACE root logging handlers and restore pre-existing ones.
+            remove_root_logging_handlers()
+            restore_root_logging_handlers(our_logging_handlers)
 
         delta_time = time.perf_counter() - start_time
 

--- a/mlptrain/potentials/mace/mace.py
+++ b/mlptrain/potentials/mace/mace.py
@@ -255,13 +255,6 @@ class MACE(MLPotential):
         import torch
         from mace.cli.run_train import run as train_mace
 
-        def root_handler_key(handler: logging.Handler) -> tuple:
-            return (
-                type(handler),
-                getattr(handler, 'baseFilename', None),
-                getattr(handler, 'stream', None),
-            )
-
         def remove_root_logging_handlers() -> list[logging.Handler]:
             """Remove and return root logging handlers before calling MACE"""
 
@@ -271,19 +264,6 @@ class MACE(MLPotential):
             for handler in root_logging_handlers:
                 root_logger.removeHandler(handler)
             return root_logging_handlers
-
-        def restore_root_logging_handlers(
-            handlers: list[logging.Handler],
-        ) -> None:
-            """Restore root handlers without adding duplicate destinations."""
-            root_logger = logging.getLogger()
-            seen = {root_handler_key(h) for h in root_logger.handlers}
-            for handler in handlers:
-                key = root_handler_key(handler)
-                if key in seen:
-                    continue
-                root_logger.addHandler(handler)
-                seen.add(key)
 
         n_cores = n_cores if n_cores is not None else Config.n_cores
         os.environ['OMP_NUM_THREADS'] = str(n_cores)
@@ -309,7 +289,9 @@ class MACE(MLPotential):
         finally:
             # Remove MACE root logging handlers and restore pre-existing ones.
             remove_root_logging_handlers()
-            restore_root_logging_handlers(our_logging_handlers)
+            root_logger = logging.getLogger()
+            for handler in our_logging_handlers:
+                root_logger.addHandler(handler)
 
         delta_time = time.perf_counter() - start_time
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,16 @@ from autode.atoms import Atom
 
 from ase.calculators.lj import Calculator, LennardJones
 
+from mlptrain.log import logger as mlp_logger
+
+
+@pytest.fixture
+def mlp_caplog(caplog):
+    """caplog for the mlptrain logger, which sets propagate = False."""
+    mlp_logger.addHandler(caplog.handler)
+    yield caplog
+    mlp_logger.removeHandler(caplog.handler)
+
 
 @pytest.fixture
 def h2():

--- a/tests/test_configuration_set.py
+++ b/tests/test_configuration_set.py
@@ -1,12 +1,26 @@
+import logging
 import os
+from contextlib import contextmanager
+
 import numpy as np
 import pytest
 from autode.atoms import Atom
 from mlptrain.configurations import ConfigurationSet, Configuration
+from mlptrain.log import logger as mlp_logger
 from mlptrain.utils import work_in_tmp_dir
 from mlptrain.box import Box
 
 here = os.path.abspath(os.path.dirname(__file__))
+
+
+@contextmanager
+def capture_mlp_logs(caplog):
+    """Capture records from the non-propagating mlptrain logger."""
+    mlp_logger.addHandler(caplog.handler)
+    try:
+        yield
+    finally:
+        mlp_logger.removeHandler(caplog.handler)
 
 
 @pytest.fixture
@@ -95,6 +109,53 @@ def test_configurations_save():
     configs.save('tmp.npz')
 
     assert os.path.exists('tmp.npz')
+
+
+@work_in_tmp_dir()
+def test_configurations_save_true_forces_without_predicted_is_quiet(caplog):
+    caplog.set_level(logging.WARNING, logger='mlptrain')
+    config = Configuration(atoms=[Atom('H')])
+    config.energy.true = -1.0
+    config.forces.true = np.ones(shape=(1, 3))
+
+    with capture_mlp_logs(caplog):
+        ConfigurationSet(config).save('tmp.npz')
+
+    assert not any(
+        'predicted forces' in record.message for record in caplog.records
+    )
+
+    loaded_config = ConfigurationSet('tmp.npz')[0]
+    assert loaded_config.forces.true is not None
+    assert loaded_config.forces.predicted is None
+
+
+@work_in_tmp_dir()
+def test_configurations_save_partially_predicted_forces_warns(caplog):
+    caplog.set_level(logging.WARNING, logger='mlptrain')
+    config1 = Configuration(atoms=[Atom('H')])
+    config1.energy.true = -1.0
+    config1.forces.true = np.ones(shape=(1, 3))
+    config1.forces.predicted = 1.1 * np.ones(shape=(1, 3))
+
+    config2 = Configuration(atoms=[Atom('He', 1.0, 0.0, 0.0)])
+    config2.energy.true = -2.0
+    config2.forces.true = 2.0 * np.ones(shape=(1, 3))
+
+    with capture_mlp_logs(caplog):
+        ConfigurationSet(config1, config2).save('tmp.npz')
+
+    assert (
+        sum(
+            'predicted forces partially defined - returning None'
+            in record.message
+            for record in caplog.records
+        )
+        == 1
+    )
+
+    loaded_configs = ConfigurationSet('tmp.npz')
+    assert all(config.forces.predicted is None for config in loaded_configs)
 
 
 @work_in_tmp_dir()

--- a/tests/test_configuration_set.py
+++ b/tests/test_configuration_set.py
@@ -1,26 +1,17 @@
 import logging
 import os
-from contextlib import contextmanager
 
 import numpy as np
 import pytest
 from autode.atoms import Atom
 from mlptrain.configurations import ConfigurationSet, Configuration
-from mlptrain.log import logger as mlp_logger
 from mlptrain.utils import work_in_tmp_dir
 from mlptrain.box import Box
 
 here = os.path.abspath(os.path.dirname(__file__))
 
-
-@contextmanager
-def capture_mlp_logs(caplog):
-    """Capture records from the non-propagating mlptrain logger."""
-    mlp_logger.addHandler(caplog.handler)
-    try:
-        yield
-    finally:
-        mlp_logger.removeHandler(caplog.handler)
+# Shared by the tests below
+_PARTIAL_FORCES_WARNING = 'predicted forces'
 
 
 @pytest.fixture
@@ -112,17 +103,19 @@ def test_configurations_save():
 
 
 @work_in_tmp_dir()
-def test_configurations_save_true_forces_without_predicted_is_quiet(caplog):
-    caplog.set_level(logging.WARNING, logger='mlptrain')
+def test_configurations_save_true_forces_without_predicted_is_quiet(
+    mlp_caplog,
+):
+    mlp_caplog.set_level(logging.WARNING, logger='mlptrain')
     config = Configuration(atoms=[Atom('H')])
     config.energy.true = -1.0
     config.forces.true = np.ones(shape=(1, 3))
 
-    with capture_mlp_logs(caplog):
-        ConfigurationSet(config).save('tmp.npz')
+    ConfigurationSet(config).save('tmp.npz')
 
     assert not any(
-        'predicted forces' in record.message for record in caplog.records
+        _PARTIAL_FORCES_WARNING in record.message
+        for record in mlp_caplog.records
     )
 
     loaded_config = ConfigurationSet('tmp.npz')[0]
@@ -131,8 +124,8 @@ def test_configurations_save_true_forces_without_predicted_is_quiet(caplog):
 
 
 @work_in_tmp_dir()
-def test_configurations_save_partially_predicted_forces_warns(caplog):
-    caplog.set_level(logging.WARNING, logger='mlptrain')
+def test_configurations_save_partially_predicted_forces_warns(mlp_caplog):
+    mlp_caplog.set_level(logging.WARNING, logger='mlptrain')
     config1 = Configuration(atoms=[Atom('H')])
     config1.energy.true = -1.0
     config1.forces.true = np.ones(shape=(1, 3))
@@ -142,14 +135,12 @@ def test_configurations_save_partially_predicted_forces_warns(caplog):
     config2.energy.true = -2.0
     config2.forces.true = 2.0 * np.ones(shape=(1, 3))
 
-    with capture_mlp_logs(caplog):
-        ConfigurationSet(config1, config2).save('tmp.npz')
+    ConfigurationSet(config1, config2).save('tmp.npz')
 
     assert (
         sum(
-            'predicted forces partially defined - returning None'
-            in record.message
-            for record in caplog.records
+            _PARTIAL_FORCES_WARNING in record.message
+            for record in mlp_caplog.records
         )
         == 1
     )

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -1,0 +1,35 @@
+import importlib
+import logging
+
+import mlptrain.log as log_module
+
+
+def test_logger_is_configured_without_root_propagation():
+    logger = log_module.logger
+
+    assert logger.name == 'mlptrain'
+    assert logger.propagate is False
+
+
+def test_logger_configuration_is_idempotent():
+    logger = log_module.logger
+    initial_handlers = list(logger.handlers)
+    initial_owned = [
+        handler
+        for handler in logger.handlers
+        if getattr(handler, '_mlptrain_handler', False)
+    ]
+
+    reloaded = importlib.reload(log_module)
+    reloaded_logger = reloaded.logger
+    reloaded_owned = [
+        handler
+        for handler in reloaded_logger.handlers
+        if getattr(handler, '_mlptrain_handler', False)
+    ]
+
+    assert reloaded_logger is logger
+    assert len(initial_owned) == 1
+    assert reloaded_logger.handlers == initial_handlers
+    assert len(reloaded_owned) == 1
+    assert isinstance(reloaded_owned[0], logging.Handler)

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -44,11 +44,8 @@ def stub_coloredlogs(monkeypatch):
     def install(**kwargs):
         kwargs['logger'].addHandler(logging.NullHandler())
 
-    module.install = install
+    module.install = install  # ty: ignore[unresolved-attribute]
     monkeypatch.setitem(sys.modules, 'coloredlogs', module)
-
-
-# --- _log_level ------------------------------------------------------------
 
 
 def test_log_level_defaults_to_info(monkeypatch):

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -1,8 +1,165 @@
+import logging
+import logging.handlers
+import re
+import sys
+import types
+
+import pytest
+
 import mlptrain.log as log_module
 
 
-def test_logger_is_configured_without_root_propagation():
-    logger = log_module.logger
+_ENV_VAR = 'MLT_LOG_LEVEL'
 
-    assert logger.name == 'mlptrain'
-    assert logger.propagate is False
+
+@pytest.fixture
+def throwaway_logger():
+    """A logger that is not registered in the global logging manager."""
+    logger = logging.Logger('mlptrain-test')
+    logger.setLevel(logging.WARNING)
+    return logger
+
+
+@pytest.fixture
+def without_coloredlogs(monkeypatch):
+    """Make ``import coloredlogs`` raise ImportError.
+
+    A None entry in sys.modules is treated by the import machinery as a
+    failed import, so this exercises the plain StreamHandler fallback even
+    when coloredlogs is installed (as it is in CI).
+    """
+    monkeypatch.setitem(sys.modules, 'coloredlogs', None)
+
+
+@pytest.fixture
+def stub_coloredlogs(monkeypatch):
+    """Replace coloredlogs with a stub that installs a marker handler.
+
+    A distinct handler is created per call because Logger.addHandler silently
+    ignores a handler it already holds. Stubbing rather than skipping keeps
+    this branch covered in environments without coloredlogs installed.
+    """
+    module = types.ModuleType('coloredlogs')
+
+    def install(**kwargs):
+        kwargs['logger'].addHandler(logging.NullHandler())
+
+    module.install = install
+    monkeypatch.setitem(sys.modules, 'coloredlogs', module)
+
+
+# --- _log_level ------------------------------------------------------------
+
+
+def test_log_level_defaults_to_info(monkeypatch):
+    monkeypatch.delenv(_ENV_VAR, raising=False)
+
+    assert log_module._log_level() == logging.INFO
+
+
+@pytest.mark.parametrize(
+    'value, expected',
+    [
+        ('WARNING', logging.WARNING),
+        ('debug', logging.DEBUG),
+        ('Critical', logging.CRITICAL),
+    ],
+)
+def test_log_level_reads_env_var(monkeypatch, value, expected):
+    monkeypatch.setenv(_ENV_VAR, value)
+
+    assert log_module._log_level() == expected
+
+
+# BASIC_FORMAT exists as an attribute of logging but is a string, not a level
+@pytest.mark.parametrize('value', ['NONSENSE', 'BASIC_FORMAT', '', '25'])
+def test_log_level_bad_value_falls_back_to_info(monkeypatch, capsys, value):
+    monkeypatch.setenv(_ENV_VAR, value)
+
+    assert log_module._log_level() == logging.INFO
+
+    stdout = capsys.readouterr().out
+    assert value in stdout
+    assert 'INFO' in stdout
+
+
+# --- _add_handler ----------------------------------------------------------
+
+
+def test_add_handler_uses_coloredlogs_when_available(
+    throwaway_logger, stub_coloredlogs
+):
+    log_module._add_handler(throwaway_logger)
+
+    # coloredlogs owns the handler, and we must not add a second one
+    assert len(throwaway_logger.handlers) == 1
+    assert isinstance(throwaway_logger.handlers[0], logging.NullHandler)
+
+
+def test_add_handler_falls_back_to_stream_handler(
+    throwaway_logger, without_coloredlogs
+):
+    log_module._add_handler(throwaway_logger)
+
+    assert len(throwaway_logger.handlers) == 1
+    handler = throwaway_logger.handlers[0]
+
+    assert isinstance(handler, logging.StreamHandler)
+    assert handler.level == throwaway_logger.level
+
+
+def test_add_handler_formats_records(
+    throwaway_logger, without_coloredlogs, capsys
+):
+    log_module._add_handler(throwaway_logger)
+
+    throwaway_logger.warning('a message')
+
+    # StreamHandler defaults to stderr
+    written = capsys.readouterr().err
+
+    assert 'mlptrain-test' in written
+    assert 'WARNING' in written
+    assert 'a message' in written
+
+    # The date is prefixed and the year is printed with only two digits
+    assert re.match(r'^\d{2}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} ', written)
+
+
+def test_add_handler_is_idempotent(throwaway_logger, without_coloredlogs):
+    """Re-configuring a logger must not duplicate its messages."""
+    log_module._add_handler(throwaway_logger)
+    log_module._add_handler(throwaway_logger)
+
+    assert len(throwaway_logger.handlers) == 1
+
+
+# --- the configured mlptrain logger ----------------------------------------
+
+
+def test_logger_is_configured_once():
+    assert len(log_module.logger.handlers) == 1
+
+
+def test_logger_records_do_not_reach_root_handlers():
+    """Records must be emitted exactly once, not also via the root logger."""
+    root_probe = logging.handlers.BufferingHandler(capacity=100)
+    mlp_probe = logging.handlers.BufferingHandler(capacity=100)
+
+    root_logger = logging.getLogger()
+    root_logger.addHandler(root_probe)
+    log_module.logger.addHandler(mlp_probe)
+
+    try:
+        # CRITICAL so that the record is emitted whatever MLT_LOG_LEVEL is set to
+        log_module.logger.critical('a message from the mlptrain logger')
+    finally:
+        root_logger.removeHandler(root_probe)
+        log_module.logger.removeHandler(mlp_probe)
+
+    assert len(mlp_probe.buffer) == 1
+    assert (
+        mlp_probe.buffer[0].getMessage()
+        == 'a message from the mlptrain logger'
+    )
+    assert root_probe.buffer == []

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -1,6 +1,3 @@
-import importlib
-import logging
-
 import mlptrain.log as log_module
 
 
@@ -9,27 +6,3 @@ def test_logger_is_configured_without_root_propagation():
 
     assert logger.name == 'mlptrain'
     assert logger.propagate is False
-
-
-def test_logger_configuration_is_idempotent():
-    logger = log_module.logger
-    initial_handlers = list(logger.handlers)
-    initial_owned = [
-        handler
-        for handler in logger.handlers
-        if getattr(handler, '_mlptrain_handler', False)
-    ]
-
-    reloaded = importlib.reload(log_module)
-    reloaded_logger = reloaded.logger
-    reloaded_owned = [
-        handler
-        for handler in reloaded_logger.handlers
-        if getattr(handler, '_mlptrain_handler', False)
-    ]
-
-    assert reloaded_logger is logger
-    assert len(initial_owned) == 1
-    assert reloaded_logger.handlers == initial_handlers
-    assert len(reloaded_owned) == 1
-    assert isinstance(reloaded_owned[0], logging.Handler)

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -8,7 +8,6 @@ import pytest
 
 import mlptrain.log as log_module
 
-
 _ENV_VAR = 'MLT_LOG_LEVEL'
 
 
@@ -57,8 +56,10 @@ def test_log_level_defaults_to_info(monkeypatch):
 @pytest.mark.parametrize(
     'value, expected',
     [
-        ('WARNING', logging.WARNING),
         ('debug', logging.DEBUG),
+        ('INfo', logging.INFO),
+        ('WARNING', logging.WARNING),
+        ('erroR', logging.ERROR),
         ('Critical', logging.CRITICAL),
     ],
 )
@@ -78,9 +79,6 @@ def test_log_level_bad_value_falls_back_to_info(monkeypatch, capsys, value):
     stdout = capsys.readouterr().out
     assert value in stdout
     assert 'INFO' in stdout
-
-
-# --- _add_handler ----------------------------------------------------------
 
 
 def test_add_handler_uses_coloredlogs_when_available(
@@ -129,9 +127,6 @@ def test_add_handler_is_idempotent(throwaway_logger, without_coloredlogs):
     log_module._add_handler(throwaway_logger)
 
     assert len(throwaway_logger.handlers) == 1
-
-
-# --- the configured mlptrain logger ----------------------------------------
 
 
 def test_logger_is_configured_once():

--- a/tests/test_mace.py
+++ b/tests/test_mace.py
@@ -2,6 +2,7 @@
 
 import importlib.util
 import logging
+from contextlib import contextmanager
 
 import pytest
 
@@ -15,6 +16,16 @@ pytestmark = pytest.mark.skipif(
     not importlib.util.find_spec('mace'),
     reason='requires MACE',
 )
+
+
+@contextmanager
+def capture_mlp_logs(caplog):
+    """Capture records from the non-propagating mlptrain logger."""
+    mlp_logger.addHandler(caplog.handler)
+    try:
+        yield
+    finally:
+        mlp_logger.removeHandler(caplog.handler)
 
 
 @pytest.fixture
@@ -49,37 +60,41 @@ def test_train_logging(
 ):
     from mlptrain.potentials import MACE
 
-    system = mlptrain.System(h2, box=Box([10, 10, 10]))
-    h2_configuration.energy.true = -0.5
-    h2o_configuration.energy.true = -1.0
+    with capture_mlp_logs(caplog):
+        system = mlptrain.System(h2, box=Box([10, 10, 10]))
+        h2_configuration.energy.true = -0.5
+        h2o_configuration.energy.true = -1.0
 
-    confs = mlptrain.ConfigurationSet(h2_configuration, h2o_configuration)
+        confs = mlptrain.ConfigurationSet(h2_configuration, h2o_configuration)
 
-    caplog.clear()
-    mlp = MACE(name='test', system=system)
-    # Check that we print MACE version in the constructor
-    assert caplog.records[0].message.startswith('MACE version:')
+        caplog.clear()
+        mlp = MACE(name='test', system=system)
+        # Check that we print MACE version in the constructor
+        assert caplog.records[0].message.startswith('MACE version:')
 
-    mlp.atomic_energies = {'H': -0.5}
+        mlp.atomic_energies = {'H': -0.5}
 
-    caplog.clear()
+        caplog.clear()
+        root_handler_count = len(logging.getLogger().handlers)
 
-    mlp.train(confs)
+        mlp.train(confs)
 
-    num_messages = len(caplog.records)
-    assert num_messages != 0
+        num_messages = len(caplog.records)
+        assert num_messages != 0
+        assert len(logging.getLogger().handlers) == root_handler_count
 
-    # Make sure we print the nodename at the start of training
-    assert caplog.records[0].message.startswith('Training on nodename')
+        # Make sure we print the nodename at the start of training
+        assert caplog.records[0].message.startswith('Training on nodename')
 
-    # Make sure that the number of log messages is the same on second call
-    caplog.clear()
-    mlp.train(confs)
-    assert len(caplog.records) == num_messages
+        # Make sure that the number of log messages is the same on second call
+        caplog.clear()
+        mlp.train(confs)
+        assert len(caplog.records) == num_messages
+        assert len(logging.getLogger().handlers) == root_handler_count
 
-    # Make sure logging is not doubled
-    caplog.clear()
-    mlp_logger.info('test info from mlp logger')
-    logging.info('test info from root logger')
+        # Make sure logging is not doubled
+        caplog.clear()
+        mlp_logger.info('test info from mlp logger')
+        logging.info('test info from root logger')
 
-    assert len(caplog.records) == 2
+        assert len(caplog.records) == 2

--- a/tests/test_mace.py
+++ b/tests/test_mace.py
@@ -2,7 +2,6 @@
 
 import importlib.util
 import logging
-from contextlib import contextmanager
 
 import pytest
 
@@ -16,16 +15,6 @@ pytestmark = pytest.mark.skipif(
     not importlib.util.find_spec('mace'),
     reason='requires MACE',
 )
-
-
-@contextmanager
-def capture_mlp_logs(caplog):
-    """Capture records from the non-propagating mlptrain logger."""
-    mlp_logger.addHandler(caplog.handler)
-    try:
-        yield
-    finally:
-        mlp_logger.removeHandler(caplog.handler)
 
 
 @pytest.fixture
@@ -56,45 +45,44 @@ def mock_mace_run_train(monkeypatch, tmp_path):
 # $ pytest --log-cli-level=INFO tests/test_mace.py::test_train_logging
 @work_in_tmp_dir()
 def test_train_logging(
-    caplog, mock_mace_run_train, h2, h2_configuration, h2o_configuration
+    mlp_caplog, mock_mace_run_train, h2, h2_configuration, h2o_configuration
 ):
     from mlptrain.potentials import MACE
 
-    with capture_mlp_logs(caplog):
-        system = mlptrain.System(h2, box=Box([10, 10, 10]))
-        h2_configuration.energy.true = -0.5
-        h2o_configuration.energy.true = -1.0
+    system = mlptrain.System(h2, box=Box([10, 10, 10]))
+    h2_configuration.energy.true = -0.5
+    h2o_configuration.energy.true = -1.0
 
-        confs = mlptrain.ConfigurationSet(h2_configuration, h2o_configuration)
+    confs = mlptrain.ConfigurationSet(h2_configuration, h2o_configuration)
 
-        caplog.clear()
-        mlp = MACE(name='test', system=system)
-        # Check that we print MACE version in the constructor
-        assert caplog.records[0].message.startswith('MACE version:')
+    mlp_caplog.clear()
+    mlp = MACE(name='test', system=system)
+    # Check that we print MACE version in the constructor
+    assert mlp_caplog.records[0].message.startswith('MACE version:')
 
-        mlp.atomic_energies = {'H': -0.5}
+    mlp.atomic_energies = {'H': -0.5}
 
-        caplog.clear()
-        root_handler_count = len(logging.getLogger().handlers)
+    mlp_caplog.clear()
+    root_handler_count = len(logging.getLogger().handlers)
 
-        mlp.train(confs)
+    mlp.train(confs)
 
-        num_messages = len(caplog.records)
-        assert num_messages != 0
-        assert len(logging.getLogger().handlers) == root_handler_count
+    num_messages = len(mlp_caplog.records)
+    assert num_messages != 0
+    assert len(logging.getLogger().handlers) == root_handler_count
 
-        # Make sure we print the nodename at the start of training
-        assert caplog.records[0].message.startswith('Training on nodename')
+    # Make sure we print the nodename at the start of training
+    assert mlp_caplog.records[0].message.startswith('Training on nodename')
 
-        # Make sure that the number of log messages is the same on second call
-        caplog.clear()
-        mlp.train(confs)
-        assert len(caplog.records) == num_messages
-        assert len(logging.getLogger().handlers) == root_handler_count
+    # Make sure that the number of log messages is the same on second call
+    mlp_caplog.clear()
+    mlp.train(confs)
+    assert len(mlp_caplog.records) == num_messages
+    assert len(logging.getLogger().handlers) == root_handler_count
 
-        # Make sure logging is not doubled
-        caplog.clear()
-        mlp_logger.info('test info from mlp logger')
-        logging.info('test info from root logger')
+    # Make sure logging is not doubled
+    mlp_caplog.clear()
+    mlp_logger.info('test info from mlp logger')
+    logging.info('test info from root logger')
 
-        assert len(caplog.records) == 2
+    assert len(mlp_caplog.records) == 2

--- a/tests/test_openmm_md.py
+++ b/tests/test_openmm_md.py
@@ -92,7 +92,7 @@ def test_openmm_simulation(h2o_system_config):
     openmm_pot_energy = (
         simulation.context.getState(getEnergy=True).getPotentialEnergy()._value
     )
-    atoms.set_calculator(mace.ase_calculator)
+    atoms.calc = mace.ase_calculator
     ase_pot_energy = atoms.get_potential_energy() / (
         (ase.units.kJ / ase.units.mol) / ase.units.eV
     )


### PR DESCRIPTION
Log lines were being emitted multiple times (duplicate handlers / root propagation). This makes logger setup deterministic and idempotent.

- Disables root propagation and makes log.py configuration idempotent via a handler marker (_mlptrain_handler), so reloading/re-importing doesn't stack handlers.
- Removes redundant handler attachment in MACE and ConfigurationSet.
- Adds tests for idempotent logger setup (test_log.py) plus MACE and ConfigurationSet logging coverage.
