### PR TITLE
Fix type checking in metadynamics.py

### DIFF
--- a/mlptrain/configurations/configuration.py
+++ b/mlptrain/configurations/configuration.py
@@ -327,6 +327,7 @@ class Configuration(AtomCollection):
         ___________________________________________________________________________
 
         """
+        assert self.atoms is not None
         # Calculate the box size if not provided, based on the maximum distance between any two atoms in the solute
         # and the buffer distance
         if box_size is None:
@@ -622,6 +623,8 @@ class Configuration(AtomCollection):
                 f'quantities to {filename}'
             )
 
+        assert self.atoms is not None
+
         if not (true or predicted):
             prop_str = ''
 
@@ -860,7 +863,7 @@ class Configuration(AtomCollection):
         # Update box if cell information is available
         cell_array = np.array(ase_atoms.get_cell())
         if np.any(cell_array != 0):
-            box = Box(np.diag(cell_array))
+            box = Box(np.diag(cell_array))  # ty: ignore[invalid-argument-type]
             logger.info(f'Updated box with dimensions: {np.diag(cell_array)}')
 
         # Load mol_dict if available
@@ -895,6 +898,9 @@ class Configuration(AtomCollection):
         """
         if not self.mol_dict:
             return True
+
+        if self.atoms is None:
+            return False
 
         total_atoms = len(self.atoms)
 

--- a/mlptrain/sampling/metadynamics.py
+++ b/mlptrain/sampling/metadynamics.py
@@ -13,10 +13,12 @@ import multiprocessing as mp
 import autode as ade
 from typing import (
     TYPE_CHECKING,
+    Any,
     Optional,
     Sequence,
     Union,
     Tuple,
+    TypedDict,
     List,
 )
 from multiprocessing import Pool
@@ -49,6 +51,15 @@ if TYPE_CHECKING:
     import ase.io
     from mlptrain.sampling.plumed import _PlumedCV
     from mlptrain.potentials import MLPotential
+
+
+class MetaParams(TypedDict):
+    mlp: MLPotential
+    configuration: Configuration
+    dt: float
+    temp: float
+    interval: int
+    sim_time_dict: dict[str, Any]
 
 
 class Metadynamics:
@@ -92,7 +103,7 @@ class Metadynamics:
 
         self.bias._set_metad_cvs(cvs)
 
-        self._previous_run_parameters = {}
+        self._previous_run_parameters: MetaParams | None = None
 
     @property
     def n_cvs(self) -> int:
@@ -642,22 +653,19 @@ class Metadynamics:
     ) -> None:
         """Set parameters in the _previous_run_parameters"""
 
+        sim_time_dict = {}
+        for key in ('ps', 'fs', 'ns'):
+            if key in kwargs:
+                sim_time_dict[key] = kwargs[key]
+
         self._previous_run_parameters = {
             'configuration': configuration,
             'mlp': mlp,
             'temp': temp,
             'dt': dt,
             'interval': interval,
+            'sim_time_dict': sim_time_dict,
         }
-
-        sim_time_dict = {}
-        for key in ['ps', 'fs', 'ns']:
-            if key in kwargs:
-                sim_time_dict[key] = kwargs[key]
-
-        self._previous_run_parameters['sim_time_dict'] = sim_time_dict
-
-        return None
 
     def plot_gaussian_heights(
         self,
@@ -1137,22 +1145,10 @@ class Metadynamics:
             pace=int(1e9), width=[1 for _ in range(self.n_cvs)], height=0
         )
 
-        if len(self._previous_run_parameters) != 0:
-            temp = float(
-                self._previous_run_parameters[
-                    'temp'
-                ]  # ty: ignore[invalid-argument-type]
-            )
-            dt = float(
-                self._previous_run_parameters[
-                    'dt'
-                ]  # ty: ignore[invalid-argument-type]
-            )
-            interval = int(
-                self._previous_run_parameters[
-                    'interval'
-                ]  # ty: ignore[invalid-argument-type]
-            )
+        if self._previous_run_parameters is not None:
+            temp = float(self._previous_run_parameters['temp'])
+            dt = float(self._previous_run_parameters['dt'])
+            interval = int(self._previous_run_parameters['interval'])
 
         elif any(param is None for param in (temp, dt, interval)):
             raise TypeError(

--- a/mlptrain/sampling/metadynamics.py
+++ b/mlptrain/sampling/metadynamics.py
@@ -11,7 +11,16 @@ import warnings
 import numpy as np
 import multiprocessing as mp
 import autode as ade
-from typing import TYPE_CHECKING, Optional, Sequence, Union, Tuple, List
+from typing import (
+    TYPE_CHECKING,
+    Literal,
+    Optional,
+    Sequence,
+    Union,
+    Tuple,
+    List,
+    overload,
+)
 from multiprocessing import Pool
 from subprocess import Popen
 from copy import deepcopy
@@ -362,7 +371,12 @@ class Metadynamics:
             kwargs['load_metad_bias'] = True
 
         if restart:
-            self._initialise_restart(width=width, n_runs=n_runs)
+            if width is None:
+                raise ValueError(
+                    'Make sure to use exactly the same width as '
+                    'in the previous simulation'
+                )
+            self._initialise_restart(n_runs=n_runs)
 
         else:
             if width is None:
@@ -471,17 +485,11 @@ class Metadynamics:
 
         return None
 
-    def _initialise_restart(self, width: Sequence, n_runs: int) -> None:
+    def _initialise_restart(self, n_runs: int) -> None:
         """
         Initialise restart for metadynamics simulation by checking
         conditions and moving files
         """
-
-        if width is None:
-            raise ValueError(
-                'Make sure to use exactly the same width as '
-                'in the previous simulation'
-            )
 
         if not os.path.exists('plumed_files/metadynamics'):
             raise FileNotFoundError(
@@ -954,7 +962,9 @@ class Metadynamics:
         if len(plotted_cvs) == 2:
             plot_cv1_and_cv2(
                 filenames=filenames,
-                cvs_units=[cv.units for cv in plotted_cvs],
+                cvs_units=[
+                    cv.units for cv in plotted_cvs
+                ],  # ty: ignore[invalid-argument-type]
                 label=f'biasf{bias.biasfactor}',
             )
 
@@ -1031,6 +1041,8 @@ class Metadynamics:
             f'trajectories/trajectory_{idx}.traj',
             index=f'{start_frame_index}:',
         )
+        if isinstance(sliced_traj, ase.Atoms):
+            sliced_traj = [sliced_traj]
         self._save_ase_traj_as_xyz(sliced_traj)
 
         shutil.copyfile(
@@ -1113,8 +1125,8 @@ class Metadynamics:
         return None
 
     def _reweighting_params(
-        self, temp: float, dt: float, interval: int
-    ) -> Tuple:
+        self, temp: float | None, dt: float | None, interval: int | None
+    ) -> tuple[PlumedBias, float, float, int]:
         """
         Read parameters required for reweighting from the previous
         metadynamics simulation. If previous parameters are not set, read
@@ -1127,14 +1139,24 @@ class Metadynamics:
             pace=int(1e9), width=[1 for _ in range(self.n_cvs)], height=0
         )
 
-        _parameters = [temp, dt, interval]
-
         if len(self._previous_run_parameters) != 0:
-            temp = float(self._previous_run_parameters['temp'])
-            dt = float(self._previous_run_parameters['dt'])
-            interval = int(self._previous_run_parameters['interval'])
+            temp = float(
+                self._previous_run_parameters[
+                    'temp'
+                ]  # ty: ignore[invalid-argument-type]
+            )
+            dt = float(
+                self._previous_run_parameters[
+                    'dt'
+                ]  # ty: ignore[invalid-argument-type]
+            )
+            interval = int(
+                self._previous_run_parameters[
+                    'interval'
+                ]  # ty: ignore[invalid-argument-type]
+            )
 
-        elif any(param is None for param in _parameters):
+        elif any(param is None for param in (temp, dt, interval)):
             raise TypeError(
                 'Metadynamics object does not have all the '
                 'required parameters to run block analysis. '
@@ -1142,10 +1164,12 @@ class Metadynamics:
                 'metadynamics run'
             )
 
-        return bias, temp, dt, interval
+        return bias, temp, dt, interval  # ty: ignore[invalid-return-type]
 
     @staticmethod
-    def _save_ase_traj_as_xyz(ase_traj: 'ase.io.trajectory.TrajectoryWriter'):
+    def _save_ase_traj_as_xyz(
+        ase_traj: ase.io.trajectory.TrajectoryWriter | list[ase.Atoms],
+    ):
         """Save ASE trajectory as .xyz file"""
 
         _mlt_configuration_set = ConfigurationSet(allow_duplicates=True)
@@ -1427,6 +1451,34 @@ class Metadynamics:
 
         return None
 
+    @overload
+    def compute_fes(
+        self,
+        energy_units: str = 'kcal mol-1',
+        n_bins: int = 300,
+        cvs_bounds: Sequence | None = None,
+        via_reweighting: Literal[True] = True,
+        start_time: float = 0.00,
+        bandwidth: float = 0.02,
+        temp: float = ...,
+        dt: float = ...,
+        interval: int = ...,
+    ) -> np.ndarray: ...
+
+    @overload
+    def compute_fes(
+        self,
+        energy_units: str = 'kcal mol-1',
+        n_bins: int = 300,
+        cvs_bounds: Sequence | None = None,
+        via_reweighting: Literal[False] = False,
+        start_time: float = 0.00,
+        bandwidth: float = 0.02,
+        temp: None = None,
+        dt: None = None,
+        interval: None = None,
+    ) -> np.ndarray: ...
+
     def compute_fes(
         self,
         energy_units: str = 'kcal mol-1',
@@ -1483,6 +1535,9 @@ class Metadynamics:
         logger.info('Computing and saving the free energy grid as fes_raw.npy')
 
         if via_reweighting:
+            assert interval is not None
+            assert dt is not None
+            assert temp is not None
             fes_raw = self._compute_fes_via_reweighting(
                 energy_units=energy_units,
                 n_bins=n_bins,
@@ -1582,6 +1637,8 @@ class Metadynamics:
         """Compute CVs and FES grids for a single run by reweighting"""
 
         sliced_traj = ase_read(traj_path, index=f'{start_frame_index}:')
+        if isinstance(sliced_traj, ase.Atoms):
+            sliced_traj = [sliced_traj]
         self._save_ase_traj_as_xyz(sliced_traj)
 
         shutil.copyfile(src=hills_path, dst=f'HILLS_{idx}.dat')
@@ -1931,7 +1988,7 @@ class Metadynamics:
 
         self._plot_surface_difference(
             fes_grids=fes_grids,
-            fes_time=fes_time,
+            fes_time=fes_time,  # ty: ignore[invalid-argument-type]
             time_units=time_units,
             energy_units=energy_units,
         )
@@ -1940,7 +1997,7 @@ class Metadynamics:
             self._plot_multiple_1d_fes_surfaces(
                 cv_grids=cv_grids,
                 fes_grids=fes_grids,
-                fes_time=fes_time,
+                fes_time=fes_time,  # ty: ignore[invalid-argument-type]
                 n_surfaces=n_surfaces,
                 time_units=time_units,
                 energy_units=energy_units,
@@ -1959,7 +2016,7 @@ class Metadynamics:
     @staticmethod
     def _plot_surface_difference(
         fes_grids: np.ndarray,
-        fes_time: List,
+        fes_time: Sequence[float],
         time_units: str,
         energy_units: str,
     ) -> None:
@@ -1993,7 +2050,7 @@ class Metadynamics:
         self,
         cv_grids: np.ndarray,
         fes_grids: np.ndarray,
-        fes_time: List,
+        fes_time: Sequence[float],
         n_surfaces: int,
         time_units: str,
         energy_units: str,

--- a/mlptrain/sampling/metadynamics.py
+++ b/mlptrain/sampling/metadynamics.py
@@ -13,13 +13,11 @@ import multiprocessing as mp
 import autode as ade
 from typing import (
     TYPE_CHECKING,
-    Literal,
     Optional,
     Sequence,
     Union,
     Tuple,
     List,
-    overload,
 )
 from multiprocessing import Pool
 from subprocess import Popen
@@ -1451,34 +1449,6 @@ class Metadynamics:
 
         return None
 
-    @overload
-    def compute_fes(
-        self,
-        energy_units: str = 'kcal mol-1',
-        n_bins: int = 300,
-        cvs_bounds: Sequence | None = None,
-        via_reweighting: Literal[True] = True,
-        start_time: float = 0.00,
-        bandwidth: float = 0.02,
-        temp: float = ...,
-        dt: float = ...,
-        interval: int = ...,
-    ) -> np.ndarray: ...
-
-    @overload
-    def compute_fes(
-        self,
-        energy_units: str = 'kcal mol-1',
-        n_bins: int = 300,
-        cvs_bounds: Sequence | None = None,
-        via_reweighting: Literal[False] = False,
-        start_time: float = 0.00,
-        bandwidth: float = 0.02,
-        temp: None = None,
-        dt: None = None,
-        interval: None = None,
-    ) -> np.ndarray: ...
-
     def compute_fes(
         self,
         energy_units: str = 'kcal mol-1',
@@ -1535,9 +1505,6 @@ class Metadynamics:
         logger.info('Computing and saving the free energy grid as fes_raw.npy')
 
         if via_reweighting:
-            assert interval is not None
-            assert dt is not None
-            assert temp is not None
             fes_raw = self._compute_fes_via_reweighting(
                 energy_units=energy_units,
                 n_bins=n_bins,
@@ -1557,12 +1524,12 @@ class Metadynamics:
 
     def _compute_fes_via_reweighting(
         self,
-        temp: float,
-        dt: float,
-        interval: int,
+        temp: float | None,
+        dt: float | None,
+        interval: int | None,
         start_time: float,
         energy_units: str,
-        cvs_bounds: Optional[Sequence],
+        cvs_bounds: Sequence | None,
         n_bins: int,
         bandwidth: float,
     ) -> np.ndarray:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,15 +56,6 @@ filterwarnings = [
 # Error if ty emits any warning-level diagnostics.
 error-on-warning = true
 
-# Enable all rules for these files
-[[tool.ty.overrides]]
-include = [
-    "mlptrain/sampling/metadynamics.py",
-]
-
-[tool.ty.overrides.rules]
-invalid-argument-type = "ignore"
-
 # Don't typecheck python scripts from examples/*_paper/
 [[tool.ty.overrides]]
 include = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,8 +59,7 @@ error-on-warning = true
 # Enable all rules for these files
 [[tool.ty.overrides]]
 include = [
-  "mlptrain/configurations/configuration.py",
-  "mlptrain/sampling/metadynamics.py",
+    "mlptrain/sampling/metadynamics.py",
 ]
 
 [tool.ty.overrides.rules]


### PR DESCRIPTION
This finally removes the rest of ignored type errors in metadynamics.py. This file is a bit of a mess in terms of types so there are a bunch of `ty: ignore`s as a pragmatic solution for now.