### PR TITLE
Add tests for ConfigurationSet addition

### DIFF
--- a/mlptrain/configurations/configuration_set.py
+++ b/mlptrain/configurations/configuration_set.py
@@ -782,8 +782,8 @@ class ConfigurationSet(list):
 
     def __add__(
         self,
-        other: 'Configuration | ConfigurationSet',
-    ) -> 'ConfigurationSet':  # ty:ignore[invalid-method-override]
+        other: object,
+    ) -> ConfigurationSet:
         """Add another configuration or set of configurations onto this one"""
 
         if isinstance(other, Configuration):

--- a/mlptrain/configurations/configuration_set.py
+++ b/mlptrain/configurations/configuration_set.py
@@ -790,17 +790,10 @@ class ConfigurationSet(list):
 
         if isinstance(other, Configuration):
             self.append(other)
-
         elif isinstance(other, ConfigurationSet):
             self.extend(other)
-
         else:
-            raise TypeError(
-                'Can only add a Configuration or'
-                f' ConfigurationSet, not {type(other)}'
-            )
-
-        logger.info(f'Current number of configurations is {len(self)}')
+            return NotImplemented
         return self
 
     def _run_parallel_method(

--- a/mlptrain/configurations/configuration_set.py
+++ b/mlptrain/configurations/configuration_set.py
@@ -234,9 +234,7 @@ class ConfigurationSet(list):
             return
 
         if not self.allow_duplicates and value in self:
-            logger.warning(
-                'Not appending configuration to set - already present'
-            )
+            logger.info('Not appending configuration to set - already present')
             return
 
         return super().append(value)

--- a/tests/test_configuration_set.py
+++ b/tests/test_configuration_set.py
@@ -69,6 +69,76 @@ def config_set_xyz_with_energies_forces():
     return configs, expected_values
 
 
+def test_addition_unsupported(mlp_caplog):
+    mlp_caplog.set_level(logging.INFO, logger='mlptrain')
+    configs = ConfigurationSet()
+
+    with pytest.raises(TypeError, match='unsupported operand type'):
+        configs + 1
+    with pytest.raises(TypeError, match='unsupported operand type'):
+        1 + configs  # ty: ignore[unsupported-operator]
+    with pytest.raises(TypeError, match='unsupported operand type'):
+        configs + None
+
+
+def test_addition_none():
+    configs = ConfigurationSet()
+    # Weirdly, appending None is silently skipped,
+    # but adding None raises TypeError!
+    configs.append(None)
+    with pytest.raises(TypeError, match='unsupported operand type'):
+        configs + None
+    assert len(configs) == 0
+
+
+def test_config_addition(mlp_caplog):
+    mlp_caplog.set_level(logging.INFO, logger='mlptrain')
+    configs = ConfigurationSet()
+    config = Configuration()
+
+    configs = configs + config
+    assert len(configs) == 1
+
+    # By default, identical configs are not added
+    configs = configs + config
+    configs.append(config)
+    assert len(configs) == 1
+
+    assert len(mlp_caplog.records) == 2
+    for record in mlp_caplog.records:
+        assert (
+            record.message
+            == 'Not appending configuration to set - already present'
+        )
+
+
+def test_config_addition_with_duplicates(mlp_caplog):
+    mlp_caplog.set_level(logging.INFO, logger='mlptrain')
+
+    config = Configuration()
+    configs_with_duplicates = ConfigurationSet(allow_duplicates=True)
+
+    configs_with_duplicates = configs_with_duplicates + config + config
+    configs_with_duplicates.append(config)
+
+    assert len(configs_with_duplicates) == 3
+    assert len(mlp_caplog.records) == 0
+
+
+def test_addition_expression():
+    """This is weird! Test that just having an addition expression
+    modifies the original ConfigurationSet
+    """
+    config = Configuration()
+    config_set = ConfigurationSet(allow_duplicates=True)
+
+    config_set + config
+    assert len(config_set) == 1
+
+    config_set + config_set
+    assert len(config_set) == 2
+
+
 @work_in_tmp_dir()
 def test_configurations_print(config_set_xyz_with_energies_forces):
     """Regression test for https://github.com/duartegroup/mlp-train/issues/223"""

--- a/tests/test_configuration_set.py
+++ b/tests/test_configuration_set.py
@@ -84,10 +84,8 @@ def test_addition_unsupported(mlp_caplog):
 def test_addition_none():
     configs = ConfigurationSet()
     # Weirdly, appending None is silently skipped,
-    # but adding None raises TypeError!
+    # (but adding None raises TypeError! See above)
     configs.append(None)
-    with pytest.raises(TypeError, match='unsupported operand type'):
-        configs + None
     assert len(configs) == 0
 
 
@@ -101,6 +99,8 @@ def test_config_addition(mlp_caplog):
 
     # By default, identical configs are not added
     configs = configs + config
+    assert len(configs) == 1
+
     configs.append(config)
     assert len(configs) == 1
 
@@ -125,9 +125,35 @@ def test_config_addition_with_duplicates(mlp_caplog):
     assert len(mlp_caplog.records) == 0
 
 
+def test_two_config_sets_addition(mlp_caplog):
+    mlp_caplog.set_level(logging.INFO, logger='mlptrain')
+
+    # Currently, adding two ConfigurationSets,
+    # or calling the "extend()" method, doesn't check for duplicates!
+    # We should probably change that!
+    config = Configuration()
+    configs1 = ConfigurationSet(config)
+    configs2 = ConfigurationSet(config)
+
+    assert len(configs1 + configs2) == 2
+
+    configs2.extend(configs2)
+    assert len(configs2) == 2
+
+
 def test_addition_expression():
-    """This is weird! Test that just having an addition expression
-    modifies the original ConfigurationSet
+    """This is weird! Just having an addition expression
+    modifies the original ConfigurationSet.
+
+    Notably, this is NOT how how stdlib list works!
+    >>> a = [1]
+    >>> a + [2]
+    [1, 2]
+    >>> a
+    [1]
+
+    Notice that the addition expression creates a copy,
+    and doesn't modify the original list `a`.
     """
     config = Configuration()
     config_set = ConfigurationSet(allow_duplicates=True)
@@ -135,6 +161,7 @@ def test_addition_expression():
     config_set + config
     assert len(config_set) == 1
 
+    # This also behaves when adding two ConfigurationSets
     config_set + config_set
     assert len(config_set) == 2
 


### PR DESCRIPTION
This PR mostly just adds tests to document the current behaviour of `ConfigurationSet.__add__` and related `append` and `extend` methods. 

The actual behaviour is not changed here, but we might want to consider changing it in a follow-up PR.

I did delete one useless logger message and downgraded one other from WARNING to INFO level.